### PR TITLE
Knock out a reaction flux

### DIFF
--- a/dingo/MetabolicNetwork.py
+++ b/dingo/MetabolicNetwork.py
@@ -214,7 +214,11 @@ class MetabolicNetwork:
 
     def shut_down_reaction(self, index_val):
 
-        if index_val < 0 or index_val >= self._S.shape[1]:
+        if (
+            (not isinstance(index_val, int))
+            or index_val < 0
+            or index_val >= self._S.shape[1]
+        ):
             raise Exception("The input does not correspond to a proper reaction index.")
 
         self._lb[index_val] = 0

--- a/dingo/MetabolicNetwork.py
+++ b/dingo/MetabolicNetwork.py
@@ -211,3 +211,11 @@ class MetabolicNetwork:
     def set_opt_percentage(self, value):
 
         self._parameters["opt_percentage"] = value
+
+    def shut_down_reaction(self, index_val):
+
+        if index_val < 0 or index_val >= self._S.shape[1]:
+            raise Exception("The input does not correspond to a proper reaction index.")
+
+        self._lb[index_val] = 0
+        self._ub[index_val] = 0

--- a/dingo/MetabolicNetwork.py
+++ b/dingo/MetabolicNetwork.py
@@ -68,7 +68,7 @@ class MetabolicNetwork:
             raise Exception(
                 "An unknown input format given to initialize a metabolic network object."
             )
-        
+
         tuple_args = read_json_file(arg)
 
         return cls(tuple_args)
@@ -79,7 +79,7 @@ class MetabolicNetwork:
             raise Exception(
                 "An unknown input format given to initialize a metabolic network object."
             )
-        
+
         tuple_args = read_mat_file(arg)
 
         return cls(tuple_args)
@@ -88,9 +88,21 @@ class MetabolicNetwork:
         """A member function to apply the FVA method on the metabolic network."""
 
         if self._parameters["fast_computations"]:
-            return fast_fva(self._lb, self._ub, self._S, self._biomass_function, self._parameters["opt_percentage"])
+            return fast_fva(
+                self._lb,
+                self._ub,
+                self._S,
+                self._biomass_function,
+                self._parameters["opt_percentage"],
+            )
         else:
-            return slow_fva(self._lb, self._ub, self._S, self._biomass_function, self._parameters["opt_percentage"])
+            return slow_fva(
+                self._lb,
+                self._ub,
+                self._S,
+                self._biomass_function,
+                self._parameters["opt_percentage"],
+            )
 
     def fba(self):
         """A member function to apply the FBA method on the metabolic network."""
@@ -146,7 +158,7 @@ class MetabolicNetwork:
 
     def num_of_reactions(self):
         return len(self._reactions)
-    
+
     def num_of_metabolites(self):
         return len(self._metabolites)
 

--- a/dingo/PolytopeSampler.py
+++ b/dingo/PolytopeSampler.py
@@ -28,9 +28,9 @@ from volestipy import HPolytope
 class PolytopeSampler:
     def __init__(self, metabol_net):
 
-        #print(isinstance(metabol_net, MetabolicNetwork))
-        #print(not isinstance(metabol_net, MetabolicNetwork))
-        #x= not isinstance(metabol_net, MetabolicNetwork)
+        # print(isinstance(metabol_net, MetabolicNetwork))
+        # print(not isinstance(metabol_net, MetabolicNetwork))
+        # x= not isinstance(metabol_net, MetabolicNetwork)
         if not isinstance(metabol_net, MetabolicNetwork):
             raise Exception("An unknown input object given for initialization.")
 
@@ -103,9 +103,12 @@ class PolytopeSampler:
                 * math.floor(max_biomass_objective / self._parameters["tol"]),
             )
 
-            self._A, self._b, self._N, self._N_shift = get_matrices_of_full_dim_polytope(
-                A, b, Aeq, beq
-            )
+            (
+                self._A,
+                self._b,
+                self._N,
+                self._N_shift,
+            ) = get_matrices_of_full_dim_polytope(A, b, Aeq, beq)
 
             n = self._A.shape[1]
             self._T = np.eye(n)
@@ -139,7 +142,9 @@ class PolytopeSampler:
             )
 
         if self._parameters["first_run_of_mmcs"]:
-            steady_states = map_samples_to_steady_states(samples, self._N, self._N_shift)
+            steady_states = map_samples_to_steady_states(
+                samples, self._N, self._N_shift
+            )
             self._parameters["first_run_of_mmcs"] = False
         else:
             steady_states = map_samples_to_steady_states(
@@ -237,7 +242,7 @@ class PolytopeSampler:
         steady_states = map_samples_to_steady_states(samples, N, N_shift)
 
         return steady_states
-    
+
     @property
     def A(self):
         return self._A

--- a/dingo/__init__.py
+++ b/dingo/__init__.py
@@ -136,9 +136,9 @@ def dingo_main():
         if args.solver != "gurobi" and args.solver != "scipy":
             raise Exception("An unknown solver requested.")
 
-        if (args.metabolic_network[-4:] == "json"):
+        if args.metabolic_network[-4:] == "json":
             model = MetabolicNetwork.fom_json(args.metabolic_network)
-        elif (args.metabolic_network[-3:] == "mat"):
+        elif args.metabolic_network[-3:] == "mat":
             model = MetabolicNetwork.fom_mat(args.metabolic_network)
         else:
             raise Exception("An unknown format file given.")
@@ -159,13 +159,13 @@ def dingo_main():
         if args.solver != "gurobi" and args.solver != "scipy":
             raise Exception("An unknown solver requested.")
 
-        if (args.metabolic_network[-4:] == "json"):
+        if args.metabolic_network[-4:] == "json":
             model = MetabolicNetwork.fom_json(args.metabolic_network)
-        elif (args.metabolic_network[-3:] == "mat"):
+        elif args.metabolic_network[-3:] == "mat":
             model = MetabolicNetwork.fom_mat(args.metabolic_network)
         else:
             raise Exception("An unknown format file given.")
-        
+
         result_obj = model.fba()
 
         with open("dingo_fba_" + name + ".pckl", "wb") as dingo_fba_file:
@@ -173,9 +173,9 @@ def dingo_main():
 
     elif args.metabolic_network is not None:
 
-        if (args.metabolic_network[-4:] == "json"):
+        if args.metabolic_network[-4:] == "json":
             model = MetabolicNetwork.fom_json(args.metabolic_network)
-        elif (args.metabolic_network[-3:] == "mat"):
+        elif args.metabolic_network[-3:] == "mat":
             model = MetabolicNetwork.fom_mat(args.metabolic_network)
         else:
             raise Exception("An unknown format file given.")

--- a/dingo/fva.py
+++ b/dingo/fva.py
@@ -81,6 +81,8 @@ def slow_fva(lb, ub, S, c, opt_percentage=100):
             if res.success:
                 min_objective = res.fun
                 min_fluxes.append(min_objective)
+            else:
+                min_fluxes.append(lb[i])
 
             # Set the minus of the ith row of the A matrix as the objective function
             objective_function = np.asarray([-x for x in objective_function])
@@ -97,6 +99,8 @@ def slow_fva(lb, ub, S, c, opt_percentage=100):
             if res.success:
                 max_objective = -res.fun
                 max_fluxes.append(max_objective)
+            else:
+                max_fluxes.append(ub[i])
 
         # Make lists of fluxes numpy arrays
         min_fluxes = np.asarray(min_fluxes)

--- a/dingo/fva.py
+++ b/dingo/fva.py
@@ -61,7 +61,7 @@ def slow_fva(lb, ub, S, c, opt_percentage=100):
     max_fluxes = []
 
     try:
-        
+
         for i in range(n):
 
             # Set the ith row of the A matrix as the objective function

--- a/dingo/gurobi_based_implementations.py
+++ b/dingo/gurobi_based_implementations.py
@@ -234,6 +234,8 @@ def fast_fva(lb, ub, S, c, opt_percentage=100):
                         # Get the min objective value
                         min_objective = model.getObjective().getValue()
                         min_fluxes.append(min_objective)
+                    else:
+                        min_fluxes.append(lb[i])
 
                     # Likewise, for the maximum
                     objective_function = np.asarray([-x for x in objective_function])
@@ -250,6 +252,8 @@ def fast_fva(lb, ub, S, c, opt_percentage=100):
                         # Get the max objective value
                         max_objective = -model.getObjective().getValue()
                         max_fluxes.append(max_objective)
+                    else:
+                        max_fluxes.append(ub[i])
 
                 # Make lists of fluxes numpy arrays
                 min_fluxes = np.asarray(min_fluxes)

--- a/tests/fast_implementation_test.py
+++ b/tests/fast_implementation_test.py
@@ -14,7 +14,6 @@ from dingo.gurobi_based_implementations import fast_inner_ball
 
 
 class TestStringMethods(unittest.TestCase):
-    
     def test_fast_max_bal_computation(self):
 
         m = 2
@@ -42,7 +41,7 @@ class TestStringMethods(unittest.TestCase):
         self.assertTrue(abs(res[3] - 0.8739215069684305) < 1e-08)
         self.assertEqual(res[0].size, 95)
         self.assertEqual(res[1].size, 95)
-    
+
     def test_ecoli_to_full_dimensional_polytope(self):
 
         current_directory = os.getcwd()
@@ -50,7 +49,7 @@ class TestStringMethods(unittest.TestCase):
 
         model = MetabolicNetwork.from_json(input_file_json)
         model.set_fast_mode()
-        
+
         sampler = PolytopeSampler(model)
         sampler.set_fast_mode()
 

--- a/tests/fast_implementation_test.py
+++ b/tests/fast_implementation_test.py
@@ -49,6 +49,8 @@ class TestStringMethods(unittest.TestCase):
         input_file_json = current_directory + "/ext_data/e_coli_core.json"
 
         model = MetabolicNetwork.from_json(input_file_json)
+        model.set_fast_mode()
+        
         sampler = PolytopeSampler(model)
         sampler.set_fast_mode()
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -15,7 +15,6 @@ from dingo.scaling import gmscale
 
 
 class TestStringMethods(unittest.TestCase):
-    
     def test_max_bal_computation(self):
 
         m = 2
@@ -37,7 +36,7 @@ class TestStringMethods(unittest.TestCase):
 
         model = MetabolicNetwork.from_json(input_file_json)
         model.set_slow_mode()
-        
+
         sampler = PolytopeSampler(model)
         sampler.set_slow_mode()
         sampler.get_polytope()

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -36,6 +36,8 @@ class TestStringMethods(unittest.TestCase):
         input_file_json = current_directory + "/ext_data/e_coli_core.json"
 
         model = MetabolicNetwork.from_json(input_file_json)
+        model.set_slow_mode()
+        
         sampler = PolytopeSampler(model)
         sampler.set_slow_mode()
         sampler.get_polytope()


### PR DESCRIPTION
This PR implements a member function in `MetabolicNetwork` class to provide the option to the user to set a reaction flux equal to zero.

The PR is based on https://github.com/GeomScale/dingo/pull/12