### PR TITLE
Add a boolean to control the preprocessing method

### DIFF
--- a/dingo/PolytopeSampler.py
+++ b/dingo/PolytopeSampler.py
@@ -50,6 +50,7 @@ class PolytopeSampler:
         ]
         self._parameters["distribution"] = "uniform"
         self._parameters["first_run_of_mmcs"] = True
+        self._parameters["remove_redundant_facets"] = True
 
         try:
             import gurobipy
@@ -79,7 +80,7 @@ class PolytopeSampler:
                 max_biomass_objective,
             ) = self._metabolic_network.fba()
 
-            if self._parameters["fast_computations"]:
+            if (self._parameters["fast_computations"] and self._parameters["remove_redundant_facets"]):
 
                 A, b, Aeq, beq = fast_remove_redundant_facets(
                     self._metabolic_network.lb,
@@ -292,6 +293,9 @@ class PolytopeSampler:
     @property
     def metabolic_network(self):
         return self._metabolic_network
+    
+    def facet_redundancy_removal(self, value):
+        self._parameters["remove_redundant_facets"] = value
 
     def set_fast_mode(self):
 

--- a/dingo/PolytopeSampler.py
+++ b/dingo/PolytopeSampler.py
@@ -7,6 +7,7 @@
 
 
 import numpy as np
+import warnings
 import math
 from dingo.MetabolicNetwork import MetabolicNetwork
 from dingo.fva import slow_fva
@@ -90,6 +91,9 @@ class PolytopeSampler:
                     self._parameters["opt_percentage"],
                 )
             else:
+                if ((not self._parameters["fast_computations"]) and self._parameters["remove_redundant_facets"]):
+                    warnings.warn("We continue without redundancy removal (slow mode is ON)")
+                
                 (
                     min_fluxes,
                     max_fluxes,
@@ -296,6 +300,9 @@ class PolytopeSampler:
     
     def facet_redundancy_removal(self, value):
         self._parameters["remove_redundant_facets"] = value
+        
+        if ((not self._parameters["fast_computations"]) and value):
+            warnings.warn("We continue without redundancy removal (slow mode is ON)")
 
     def set_fast_mode(self):
 

--- a/dingo/PolytopeSampler.py
+++ b/dingo/PolytopeSampler.py
@@ -81,7 +81,10 @@ class PolytopeSampler:
                 max_biomass_objective,
             ) = self._metabolic_network.fba()
 
-            if (self._parameters["fast_computations"] and self._parameters["remove_redundant_facets"]):
+            if (
+                self._parameters["fast_computations"]
+                and self._parameters["remove_redundant_facets"]
+            ):
 
                 A, b, Aeq, beq = fast_remove_redundant_facets(
                     self._metabolic_network.lb,
@@ -91,9 +94,13 @@ class PolytopeSampler:
                     self._parameters["opt_percentage"],
                 )
             else:
-                if ((not self._parameters["fast_computations"]) and self._parameters["remove_redundant_facets"]):
-                    warnings.warn("We continue without redundancy removal (slow mode is ON)")
-                
+                if (not self._parameters["fast_computations"]) and self._parameters[
+                    "remove_redundant_facets"
+                ]:
+                    warnings.warn(
+                        "We continue without redundancy removal (slow mode is ON)"
+                    )
+
                 (
                     min_fluxes,
                     max_fluxes,
@@ -297,12 +304,14 @@ class PolytopeSampler:
     @property
     def metabolic_network(self):
         return self._metabolic_network
-    
+
     def facet_redundancy_removal(self, value):
         self._parameters["remove_redundant_facets"] = value
-        
-        if ((not self._parameters["fast_computations"]) and value):
-            warnings.warn("We continue without redundancy removal (slow mode is ON)")
+
+        if (not self._parameters["fast_computations"]) and value:
+            warnings.warn(
+                "Since you are in slow mode the redundancy removal step is skipped (dingo does not currently support this functionality in slow mode)"
+            )
 
     def set_fast_mode(self):
 


### PR DESCRIPTION
This PR adds a boolean member variable in `PolytopeSampler` class of dingo. The variable controls if dingo removes the redundant facets in the preprocess or not. The default value is

`self._parameters["remove_redundant_facets"] = True`. 