### PR TITLE
Expose rounding methods

### DIFF
--- a/dingo/PolytopeSampler.py
+++ b/dingo/PolytopeSampler.py
@@ -217,6 +217,19 @@ class PolytopeSampler:
         return samples
 
     @staticmethod
+    def round_polytope(
+        A, b, method = "john_position"
+    ):
+        P = HPolytope(A, b)
+        try:
+            import gurobipy
+            A, b, Tr, Tr_shift, round_value = P.rounding(method, True)
+        except ImportError as e:
+            A, b, Tr, Tr_shift, round_value = P.rounding(method, False)
+        
+        return A, b, Tr, Tr_shift
+
+    @staticmethod
     def sample_from_fva_output(
         min_fluxes,
         max_fluxes,

--- a/dingo/bindings/bindings.cpp
+++ b/dingo/bindings/bindings.cpp
@@ -481,7 +481,7 @@ void HPolytopeCPP::apply_rounding(int rounding_method, double* new_A, double* ne
       round_res = max_inscribed_ellipsoid_rounding<MT, VT, NT>(P, CheBall.first);
       
    } else if (rounding_method == 2) { // isotropization
-      round_res = svd_rounding<AcceleratedBilliardWalk, MT, VT>(P, CheBall, walk_len, rng);
+      round_res = svd_rounding<AcceleratedBilliardWalk, MT, VT>(P, CheBall, 1, rng);
    } else if (rounding_method == 3) { // min ellipsoid
       round_res = min_sampling_covering_ellipsoid_rounding<AcceleratedBilliardWalk, MT, VT>(P,
                                                                                             CheBall,

--- a/dingo/bindings/bindings.cpp
+++ b/dingo/bindings/bindings.cpp
@@ -81,13 +81,13 @@ double HPolytopeCPP::compute_volume(char* vol_method, char* walk_method,
 
 
 //////////         Start of "generate_samples()"          //////////
-double HPolytopeCPP::generate_samples(int walk_len,
-                                      int number_of_points, 
-                                      int number_of_points_to_burn,
-                                      int method,
-                                      double* inner_point, 
-                                      double radius,
-                                      double* samples) {
+double HPolytopeCPP::apply_sampling(int walk_len,
+                                    int number_of_points, 
+                                    int number_of_points_to_burn,
+                                    int method,
+                                    double* inner_point, 
+                                    double radius,
+                                    double* samples) {
    RNGType rng(HP.dimension());
    HP.normalize();
    int d = HP.dimension();

--- a/dingo/bindings/bindings.h
+++ b/dingo/bindings/bindings.h
@@ -139,9 +139,9 @@ class HPolytopeCPP{
       // the compute_volume() function
       double compute_volume(char* vol_method, char* walk_method, int walk_len, double epsilon, int seed) const;
 
-      // the generate_samples() function
-      double generate_samples(int walk_len, int number_of_points, int number_of_points_to_burn,
-                              int method, double* inner_point, double radius, double* samples);
+      // the apply_sampling() function
+      double apply_sampling(int walk_len, int number_of_points, int number_of_points_to_burn,
+                            int method, double* inner_point, double radius, double* samples);
 
       void mmcs_initialize(int d, int ess, bool psrf_check, bool parallelism, int num_threads);
 

--- a/dingo/bindings/bindings.h
+++ b/dingo/bindings/bindings.h
@@ -154,8 +154,8 @@ class HPolytopeCPP{
       void get_polytope_as_matrices(double* new_A, double* new_b) const;
 
       // the rounding() function
-      void rounding(char* rounding_method, double* new_A, double* new_b, double* T_matrix, double* shift, double &round_value,
-       bool max_ball, double* inner_point, double radius);
+      void apply_rounding(int rounding_method, double* new_A, double* new_b, double* T_matrix, 
+                          double* shift, double &round_value, double* inner_point, double radius);
       
 };
 

--- a/dingo/volestipy.pyx
+++ b/dingo/volestipy.pyx
@@ -75,7 +75,7 @@ cdef extern from "bindings.h":
 
       # Rounding H-Polytope
       void apply_rounding(int rounding_method, double* new_A, double* new_b, double* T_matrix, \
-                          double* shift, double &round_value, double* inner_point, double radius
+                          double* shift, double &round_value, double* inner_point, double radius);
 
    # The lowDimPolytopeCPP class along with its functions
    cdef cppclass lowDimHPolytopeCPP:

--- a/dingo/volestipy.pyx
+++ b/dingo/volestipy.pyx
@@ -58,7 +58,7 @@ cdef extern from "bindings.h":
       double compute_volume(char* vol_method, char* walk_method, int walk_len, double epsilon, int seed);
 
       # Random sampling
-      double generate_samples(int walk_len, int number_of_points, int number_of_points_to_burn, \
+      double apply_sampling(int walk_len, int number_of_points, int number_of_points_to_burn, \
                               int method, double* inner_point, double radius, double* samples)
       
       # Initialize the parameters for the (m)ultiphase (m)onte (c)arlo (s)ampling algorithm
@@ -125,7 +125,7 @@ cdef class HPolytope:
    def generate_samples(self, method, number_of_points, number_of_points_to_burn, walk_len, fast_mode):
 
       n_variables = self._A.shape[1]
-      cdef double[:,::1] samples = np.zeros((n_variables, number_of_points), dtype = np.float64, order = "C")
+      cdef double[:,::1] samples = np.zeros((number_of_points, n_variables), dtype = np.float64, order = "C")
 
       # Get max inscribed ball for the initial polytope
       if fast_mode:
@@ -152,9 +152,9 @@ cdef class HPolytope:
       else:
          raise RuntimeError("Uknown MCMC sampling method")
       
-      self.polytope_cpp.generate_samples(walk_len, number_of_points, number_of_points_to_burn, \
-                                         int_method, &inner_point_for_c[0], radius, &samples[0,0])
-      return np.asarray(samples)      # we need to build a Python function for getting a starting point depending on the polytope
+      self.polytope_cpp.apply_sampling(walk_len, number_of_points, number_of_points_to_burn, \
+                                       int_method, &inner_point_for_c[0], radius, &samples[0,0])
+      return np.asarray(samples)
 
 
    # The rounding() function; as in compute_volume, more than one method is available for this step

--- a/dingo/volestipy.pyx
+++ b/dingo/volestipy.pyx
@@ -170,15 +170,8 @@ cdef class HPolytope:
          int_method = 3
       else:
          raise RuntimeError("Uknown rounding method")
-      
-      # Check whether the rounding method the user asked for is actually among those volestipy supports
-      #if rounding_method in rounding_methods:
 
       self.polytope_cpp.apply_rounding(int_method, &new_A[0,0], &new_b[0], &T_matrix[0,0], &shift[0], round_value, &inner_point_for_c[0], radius)
-
-         #np.save('A_rounded.npy', new_A) ; np.save('b_rounded.npy', new_b)
-         #np.save('T_rounded.npy', T_matrix) ; np.save('shift_rounded.npy', shift)
-         #np.save('round_value.npy', np.asarray(round_value))
 
       return np.asarray(new_A),np.asarray(new_b),np.asarray(T_matrix),np.asarray(shift),np.asarray(round_value)
    

--- a/doc/documentation_package.md
+++ b/doc/documentation_package.md
@@ -34,6 +34,38 @@ The default option is to run the sequential [Multiphase Monte Carlo Sampling alg
 
 **Tip**: After the first run of MMCS algorithm the polytope stored in object `sampler` is usually more rounded than the initial one. Thus, the function `generate_steady_states()` becomes more efficient from run to run.  
 
+
+#### Rounding the polytope
+
+`dingo` provides three methods to round a polytope: (i) Bring the polytope to John position by apllying to it the transformation that maps the largest inscribed ellipsoid of the polytope to the unit ball, (ii) Bring the polytope to near-isotropic position by using uniform sampling with Billiard Walk, (iii) Apply to the polytope the transformation that maps the smallest enclosing ellipsoid of a uniform sample from the interior of the polytope to the unit ball.  
+
+```python
+from dingo import MetabolicNetwork, PolytopeSampler
+
+model = MetabolicNetwork.from_json('path/to/model_file.json')
+sampler = PolytopeSampler(model)
+A, b, N, N_shift = sampler.get_polytope()
+
+A_rounded, b_rounded, Tr, Tr_shift = sampler.round_polytope(A, b, method="john_postiion")
+A_rounded, b_rounded, Tr, Tr_shift = sampler.round_polytope(A, b, method="isotropic_postiion")
+A_rounded, b_rounded, Tr, Tr_shift = sampler.round_polytope(A, b, method="min_ellipsoid")
+```
+
+Then, to sample from the rounded polytope, the user has to call the following static method of PolytopeSampler class,
+
+```python
+samples = sample_from_polytope(A_rounded, b_rounded)
+```
+
+Last you can map the samples back to steady states,
+
+```python
+from dingo import map_samples_to_steady_states
+
+steady_states = map_samples_to_steady_states(samples, N, N_shift, Tr, Tr_shift)
+```
+
+
 #### Fast and slow mode
 
 If you have installed successfully the `gurobi` library, dingo turns to the *fast mode* by default. To set a certain mode you could use the following member functions,

--- a/tests/rounding.py
+++ b/tests/rounding.py
@@ -1,0 +1,100 @@
+# dingo : a python library for metabolic networks sampling and analysis
+# dingo is part of GeomScale project
+
+# Copyright (c) 2022 Apostolos Chalkis
+# Copyright (c) 2022 Vissarion Fisikopoulos
+# Copyright (c) 2022 Haris Zafeiropoulos
+
+# Licensed under GNU LGPL.3, see LICENCE file
+
+import unittest
+import os
+import numpy as np
+from dingo import MetabolicNetwork, PolytopeSampler
+from dingo.gurobi_based_implementations import fast_inner_ball
+
+class TestSampling(unittest.TestCase):
+
+    def test_rounding_min_ellipsoid(self):
+
+        input_file_json = os.getcwd() + "/ext_data/e_coli_core.json"
+        model = MetabolicNetwork.from_json( input_file_json )
+        sampler = PolytopeSampler(model)
+
+        A, b, N, N_shift = sampler.get_polytope()
+
+        A_rounded, b_rounded, Tr, Tr_shift = sampler.round_polytope(A, b, method="min_ellipsoid")
+
+        self.assertTrue( A_rounded.shape[0] == 26 )
+        self.assertTrue( A_rounded.shape[1] == 24 )
+
+        self.assertTrue( b.size == 26 )
+        self.assertTrue( N_shift.size == 95 )
+        self.assertTrue( b_rounded.size == 26 )
+        self.assertTrue( Tr_shift.size == 24 )
+        
+
+        self.assertTrue( N.shape[0] == 95 )
+        self.assertTrue( N.shape[1] == 24 )
+
+        self.assertTrue( Tr.shape[0] == 24 )
+        self.assertTrue( Tr.shape[1] == 24 )
+
+        samples = sampler.sample_from_polytope_no_multiphase(
+            A_rounded, b_rounded, method = 'billiard_walk', n=1000, burn_in=10, thinning=1
+        )
+
+        temp = np.full((samples.shape[0], samples.shape[1]), Tr_shift)
+        Tr_samples = Tr.dot(samples.T) + temp.T
+        all_points_in = True
+        for i in range(Tr_samples.shape[1]):
+            if np.any(A.dot(Tr_samples[:,i]) - b > 1e-05):
+                all_points_in = False
+                break
+        
+        self.assertTrue( all_points_in )
+
+    def test_rounding_john_position(self):
+
+        input_file_json = os.getcwd() + "/ext_data/e_coli_core.json"
+        model = MetabolicNetwork.from_json( input_file_json )
+        sampler = PolytopeSampler(model)
+
+        A, b, N, N_shift = sampler.get_polytope()
+
+        A_rounded, b_rounded, Tr, Tr_shift = sampler.round_polytope(A, b, method="john_position")
+
+        self.assertTrue( A_rounded.shape[0] == 26 )
+        self.assertTrue( A_rounded.shape[1] == 24 )
+
+        self.assertTrue( b.size == 26 )
+        self.assertTrue( N_shift.size == 95 )
+        self.assertTrue( b_rounded.size == 26 )
+        self.assertTrue( Tr_shift.size == 24 )
+        
+
+        self.assertTrue( N.shape[0] == 95 )
+        self.assertTrue( N.shape[1] == 24 )
+
+        self.assertTrue( Tr.shape[0] == 24 )
+        self.assertTrue( Tr.shape[1] == 24 )
+
+        samples = sampler.sample_from_polytope_no_multiphase(
+            A_rounded, b_rounded, method = 'billiard_walk', n=1000, burn_in=10, thinning=1
+        )
+
+        temp = np.full((samples.shape[0], samples.shape[1]), Tr_shift)
+        Tr_samples = Tr.dot(samples.T) + temp.T
+        all_points_in = True
+        for i in range(Tr_samples.shape[1]):
+            if np.any(A.dot(Tr_samples[:,i]) - b > 1e-05):
+                all_points_in = False
+                break
+        
+        self.assertTrue( all_points_in )
+
+
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR exposes the rounding methods of volesti in dingo.

Let load a model,

```python
from dingo import MetabolicNetwork, PolytopeSampler
model = MetabolicNetwork.from_json('/path/to/e_coli_core.json')
sampler = PolytopeSampler(model)
```

Then, the user has to call the following static method in PolytopeSampler:

```python
A = sampler.A
b = sampler.b
A_rounded, b_rounded, Tr, Tr_shift = sampler.round_polytope(A, b, method="john_position")
A_rounded, b_rounded, Tr, Tr_shift = sampler.round_polytope(A, b, method="isotropic_position")
A_rounded, b_rounded, Tr, Tr_shift = sampler.round_polytope(A, b, method="min_ellipsoid")
```