### PR TITLE
support of medium modification and cobra model loading

### DIFF
--- a/dingo/MetabolicNetwork.py
+++ b/dingo/MetabolicNetwork.py
@@ -8,6 +8,7 @@
 
 import numpy as np
 import sys
+from typing import Dict
 import cobra
 from dingo.loading_models import read_json_file, read_mat_file, read_sbml_file, parse_cobra_model
 from dingo.fva import slow_fva
@@ -222,7 +223,7 @@ class MetabolicNetwork:
 
 
     @medium.setter
-    def medium(self, medium: dict[str, float]) -> None:
+    def medium(self, medium: Dict[str, float]) -> None:
         """Set the constraints on the model exchanges.
 
         `model.medium` returns a dictionary of the bounds for each of the

--- a/dingo/MetabolicNetwork.py
+++ b/dingo/MetabolicNetwork.py
@@ -8,7 +8,8 @@
 
 import numpy as np
 import sys
-from dingo.loading_models import read_json_file, read_mat_file, read_sbml_file
+import cobra
+from dingo.loading_models import read_json_file, read_mat_file, read_sbml_file, parse_cobra_model
 from dingo.fva import slow_fva
 from dingo.fba import slow_fba
 
@@ -34,7 +35,7 @@ class MetabolicNetwork:
         except ImportError as e:
             self._parameters["fast_computations"] = False
 
-        if len(tuple_args) != 7:
+        if len(tuple_args) != 10:
             raise Exception(
                 "An unknown input format given to initialize a metabolic network object."
             )
@@ -46,6 +47,9 @@ class MetabolicNetwork:
         self._reactions = tuple_args[4]
         self._biomass_index = tuple_args[5]
         self._biomass_function = tuple_args[6]
+        self._medium = tuple_args[7]
+        self._medium_indices = tuple_args[8]
+        self._exchanges = tuple_args[9]
 
         try:
             if self._biomass_index is not None and (
@@ -83,12 +87,21 @@ class MetabolicNetwork:
 
     @classmethod
     def from_sbml(cls, arg):
-        if (not isinstance(arg, str)) or (arg[-3:] != "xml"):
+        if (not isinstance(arg, str)) and ((arg[-3:] == "xml") or (arg[-4] == "sbml")):
             raise Exception(
                 "An unknown input format given to initialize a metabolic network object."
             )
 
         return cls(read_sbml_file(arg))
+
+    @classmethod
+    def from_cobra_model(cls, arg):
+        if (not isinstance(arg, cobra.core.model.Model)):
+            raise Exception(
+                "An unknown input format given to initialize a metabolic network object."
+            )
+
+        return cls(parse_cobra_model(arg))
 
     def fva(self):
         """A member function to apply the FVA method on the metabolic network."""
@@ -147,6 +160,14 @@ class MetabolicNetwork:
         return self._biomass_function
 
     @property
+    def medium(self):
+        return self._medium
+
+    @property
+    def exchanges(self):
+        return self._exchanges
+
+    @property
     def parameters(self):
         return self._parameters
 
@@ -160,6 +181,9 @@ class MetabolicNetwork:
             self._reactions,
             self._biomass_index,
             self._biomass_function,
+            self._medium,
+            self._inter_medium,
+            self._exchanges
         )
 
     def num_of_reactions(self):
@@ -195,6 +219,72 @@ class MetabolicNetwork:
     @biomass_function.setter
     def biomass_function(self, value):
         self._biomass_function = value
+
+
+    @medium.setter
+    def medium(self, medium: dict[str, float]) -> None:
+        """Set the constraints on the model exchanges.
+
+        `model.medium` returns a dictionary of the bounds for each of the
+        boundary reactions, in the form of `{rxn_id: rxn_bound}`, where `rxn_bound`
+        specifies the absolute value of the bound in direction of metabolite
+        creation (i.e., lower_bound for `met <--`, upper_bound for `met -->`)
+
+        Parameters
+        ----------
+        medium: dict
+            The medium to initialize. medium should be a dictionary defining
+            `{rxn_id: bound}` pairs.
+        """
+
+        def set_active_bound(reaction: str, reac_index: int, bound: float) -> None:
+            """Set active bound.
+
+            Parameters
+            ----------
+            reaction: cobra.Reaction
+                Reaction to set
+            bound: float
+                Value to set bound to. The bound is reversed and set as lower bound
+                if reaction has reactants (metabolites that are consumed). If reaction
+                has reactants, it seems the upper bound won't be set.
+            """
+            if any(x < 0 for x in  list(self._S[:, reac_index])):
+                self._lb[reac_index] = -bound
+            elif any(x > 0 for x in  list(self._S[:, reac_index])):
+                self._ub[reac_index] = bound
+
+        # Set the given media bounds
+        media_rxns = []
+        exchange_rxns = frozenset(self.exchanges)
+        for rxn_id, rxn_bound in medium.items():
+            if rxn_id not in exchange_rxns:
+                logger.warning(
+                    f"{rxn_id} does not seem to be an an exchange reaction. "
+                    f"Applying bounds anyway."
+                )
+            media_rxns.append(rxn_id)
+
+            reac_index = self._reactions.index(rxn_id)
+
+            set_active_bound(rxn_id, reac_index, rxn_bound)
+
+        frozen_media_rxns = frozenset(media_rxns)
+
+        # Turn off reactions not present in media
+        for rxn_id in exchange_rxns - frozen_media_rxns:
+            """
+            is_export for us, needs to check on the S 
+            order reactions to their lb and ub 
+            """
+            # is_export = rxn.reactants and not rxn.products
+            reac_index = self._reactions.index(rxn_id)
+            products = np.any(self._S[:,reac_index] > 0) 
+            reactants_exist = np.any(self._S[:,reac_index] < 0)
+            is_export = True if not products and reactants_exist else False
+            set_active_bound(
+                rxn_id, reac_index, min(0.0, -self._lb[reac_index] if is_export else self._ub[reac_index])
+            )
 
     def set_fast_mode(self):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ argparse = "^1.4.0"
 matplotlib = "^3.4.1"
 cobra = "^0.26.0"
 plotly = "^5.11.0"
-#kaleido = "0.2.1"
 kaleido = "0.2.1"
 
 [tool.poetry.dev-dependencies]

--- a/tests/fba.py
+++ b/tests/fba.py
@@ -10,7 +10,7 @@ import os
 from dingo import MetabolicNetwork
 
 class TestFba(unittest.TestCase):
-    
+
     def test_fba_json(self):
 
         input_file_json = os.getcwd() + "/ext_data/e_coli_core.json"
@@ -21,7 +21,7 @@ class TestFba(unittest.TestCase):
         self.assertTrue(abs(res[1] - 0.8739215067486387) < 1e-03)
 
     def test_fba_mat(self):
-        
+
         input_file_mat = os.getcwd() + "/ext_data/e_coli_core.mat"
         model = MetabolicNetwork.from_mat(input_file_mat)
         model.set_slow_mode()
@@ -49,26 +49,33 @@ class TestFba(unittest.TestCase):
         initial_medium = model.medium
         initial_fba = model.fba()[-1]
 
-        initial_medium_indices = {}
-        for reac in initial_medium:
-            initial_medium_indices[reac] = model.reactions.index(reac)
+        e_coli_core_medium_compound_indices = {
+            "EX_co2_e" : 46,
+            "EX_glc__D_e" : 51,
+            "EX_h_e" : 54,
+            "EX_h2o_e" : 55,
+            "EX_nh4_e" : 58,
+            "EX_o2_e" : 59,
+            "EX_pi_e" : 60
+        }
 
         glc_index = model.reactions.index("EX_glc__D_e")
+        o2_index = model.reactions.index("EX_o2_e")
 
         new_media = initial_medium.copy()
         new_media["EX_glc__D_e"] = 1.5
+        new_media["EX_o2_e"] = -0.5
 
         model.medium = new_media
 
         updated_media = model.medium
         updated_medium_indices = {}
         for reac in updated_media:
-            updated_medium_indices[reac] = model.reactions.index(reac)        
+            updated_medium_indices[reac] = model.reactions.index(reac)
 
-        if len(updated_media) == len(new_media):
-            self.assertTrue(updated_medium_indices == initial_medium_indices)
+        self.assertTrue(updated_medium_indices == e_coli_core_medium_compound_indices)
 
-        self.assertTrue(model.lb[glc_index] == -1.5)
+        self.assertTrue(model.lb[glc_index] == -1.5 and model.lb[o2_index] == 0.5)
 
         self.assertTrue(initial_fba - model.fba()[-1] > 0)
 

--- a/tests/fba.py
+++ b/tests/fba.py
@@ -48,6 +48,11 @@ class TestFba(unittest.TestCase):
 
         initial_medium = model.medium
         initial_fba = model.fba()[-1]
+
+        initial_medium_indices = {}
+        for reac in initial_medium:
+            initial_medium_indices[reac] = model.reactions.index(reac)
+
         glc_index = model.reactions.index("EX_glc__D_e")
 
         new_media = initial_medium.copy()
@@ -55,8 +60,15 @@ class TestFba(unittest.TestCase):
 
         model.medium = new_media
 
-        if model.lb[glc_index] != -1.5:
-            self.assertTrue(model.lb[glc_index] == -1.5)
+        updated_media = model.medium
+        updated_medium_indices = {}
+        for reac in updated_media:
+            updated_medium_indices[reac] = model.reactions.index(reac)        
+
+        if len(updated_media) == len(new_media):
+            self.assertTrue(updated_medium_indices == initial_medium_indices)
+
+        self.assertTrue(model.lb[glc_index] == -1.5)
 
         self.assertTrue(initial_fba - model.fba()[-1] > 0)
 

--- a/tests/fba.py
+++ b/tests/fba.py
@@ -40,6 +40,26 @@ class TestFba(unittest.TestCase):
 
         self.assertTrue(abs(res[1] - 0.8739215067486387) < 1e-03)
 
+    def test_modify_medium(self):
+
+        input_file_sbml = os.getcwd() + "/ext_data/e_coli_core.xml"
+        model = MetabolicNetwork.from_sbml(input_file_sbml)
+        model.set_slow_mode()
+
+        initial_medium = model.medium
+        initial_fba = model.fba()[-1]
+        glc_index = model.reactions.index("EX_glc__D_e")
+
+        new_media = initial_medium.copy()
+        new_media["EX_glc__D_e"] = 1.5
+
+        model.medium = new_media
+
+        if model.lb[glc_index] != -1.5:
+            self.assertTrue(model.lb[glc_index] == -1.5)
+
+        self.assertTrue(initial_fba - model.fba()[-1] > 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Aim of this PR is to address issues #74 and #75 .

The `MetabolicNetwork` class has been modified now it keeps the exchange reactions of a model as `model.exchanges` and its medium as `model.medium`. 

The user may modify the medium as in cobra. 

On top of that, `dingo` can also now build a dingo-model based on a cobra-model.
For example:

```
import cobra 
import dingo 

cobra_model = cobra.io.read_sbml_model("my_model.xml")
dingo_model = dingo.MetabolicNetwork.from_cobra_model(cobra_model)
```
This allows for further modifications of the model, e.g. adding reactions, through the 
convenient interface of cobra and an easier integration with dingo. 


