### PR TITLE
solve issue #83:  generate_steady_states fails when you edit a model's optimal percentage twice #83 

### DIFF
--- a/dingo/gurobi_based_implementations.py
+++ b/dingo/gurobi_based_implementations.py
@@ -108,8 +108,8 @@ def fast_fba(lb, ub, S, c):
                     optimum_value = -model.getObjective().getValue()
                     v = model.getVars()
 
-                for i in range(n):
-                    optimum_sol.append(v[i].x)
+                    for i in range(n):
+                        optimum_sol.append(v[i].x)
 
                 optimum_sol = np.asarray(optimum_sol)
 


### PR DESCRIPTION
This is related to GeomScale/dingo issue #83 - https://github.com/GeomScale/dingo/issues/83

 Reproduced the specified issue (referenced as #83) in my local development environment.
```
model = dingo.MetabolicNetwork.from_json("ext_data/e_coli_core.json")

model.set_opt_percentage(90)
sampler = dingo.PolytopeSampler(model)
sampler.generate_steady_states()

model.set_opt_percentage(20)
sampler = dingo.PolytopeSampler(model)
sampler.generate_steady_states()
```
```
OUTPUT: UnboundLocalError: local variable 'v' referenced before assignment
```
Error is related to the https://github.com/GeomScale/dingo/blob/aaae4ae63f432da45eb0f4363a92767ba537a074/dingo/gurobi_based_implementations.py#L109 and the status == GRB.OPTIMAL that is not the case in the second edit.

**Source:**  - Trying to access a variable which is defined only if status == GRB.OPTIMAL in 
```
                # If optimized
                status = model.status
                if status == GRB.OPTIMAL:
                    optimum_value = -model.getObjective().getValue()
                    v = model.getVars() 
```
**Solution:** - Access variable only if it is declared
```
                # If optimized
                status = model.status
                if status == GRB.OPTIMAL:
                    optimum_value = -model.getObjective().getValue()
                    v = model.getVars()

                    for i in range(n):
                        optimum_sol.append(v[i].x)
```
OUTPUT after modification : 
```
phase 1: number of correlated samples = 500, effective sample size = 6, ratio of the maximum singilar value over the minimum singular value = 2175.82
phase 2: number of correlated samples = 500, effective sample size = 143, ratio of the maximum singilar value over the minimum singular value = 5.51623
phase 3: number of correlated samples = 500, effective sample size = 158, ratio of the maximum singilar value over the minimum singular value = 2.59844
phase 4: number of correlated samples = 1700, effective sample size = 770
[5]total ess 1077: number of correlated samples = 3200
[5]maximum marginal PSRF: 1.05362


phase 1: number of correlated samples = 600, effective sample size = 4, ratio of the maximum singilar value over the minimum singular value = 2611.83
phase 2: number of correlated samples = 600, effective sample size = 3, ratio of the maximum singilar value over the minimum singular value = 2274.04
phase 3: number of correlated samples = 600, effective sample size = 3, ratio of the maximum singilar value over the minimum singular value = 3640.99
phase 4: number of correlated samples = 600, effective sample size = 3, ratio of the maximum singilar value over the minimum singular value = 5323.01
phase 5: number of correlated samples = 600, effective sample size = 3, ratio of the maximum singilar value over the minimum singular value = 4125.15
phase 6: number of correlated samples = 600, effective sample size = 3, ratio of the maximum singilar value over the minimum singular value = 3424.12
phase 7: number of correlated samples = 600, effective sample size = 3, ratio of the maximum singilar value over the minimum singular value = 4738.09
phase 8: number of correlated samples = 600, effective sample size = 3, ratio of the maximum singilar value over the minimum singular value = 5004.78
phase 9: number of correlated samples = 600, effective sample size = 3, ratio of the maximum singilar value over the minimum singular value = 3640.73
phase 10: number of correlated samples = 600, effective sample size = 3, ratio of the maximum singilar value over the minimum singular value = 3435.86
phase 11: number of correlated samples = 600, effective sample size = 3, ratio of the maximum singilar value over the minimum singular value = 3554.87
phase 12: number of correlated samples = 600, effective sample size = 3, ratio of the maximum singilar value over the minimum singular value = 4256.1
phase 13: number of correlated samples = 600, effective sample size = 3, ratio of the maximum singilar value over the minimum singular value = 4137.46
phase 14: number of correlated samples = 600, effective sample size = 3, ratio of the maximum singilar value over the minimum singular value = 3557.47
phase 15: number of correlated samples = 600, effective sample size = 3, ratio of the maximum singilar value over the minimum singular value = 3842.69
phase 16: number of correlated samples = 600, effective sample size = 3, ratio of the maximum singilar value over the minimum singular value = 3625.27
phase 17: number of correlated samples = 600, effective sample size = 3, ratio of the maximum singilar value over the minimum singular value = 3911.47
phase 18: number of correlated samples = 600, effective sample size = 3, ratio of the maximum singilar value over the minimum singular value = 4738.21
phase 19: number of correlated samples = 600, effective sample size = 3, ratio of the maximum singilar value over the minimum singular value = 4355.26
phase 20: number of correlated samples = 600, effective sample size = 3, ratio of the maximum singilar value over the minimum singular value = 3726.65
phase 21: number of correlated samples = 2800, effective sample size = 18
phase 22: number of correlated samples = 2800, effective sample size = 18
phase 23: number of correlated samples = 2800, effective sample size = 18
phase 24: number of correlated samples = 2800, effective sample size = 18
phase 25: number of correlated samples = 2800, effective sample size = 18
phase 26: number of correlated samples = 2800, effective sample size = 18
phase 27: number of correlated samples = 2800, effective sample size = 18
phase 28: number of correlated samples = 2800, effective sample size = 17
phase 29: number of correlated samples = 2800, effective sample size = 18
phase 30: number of correlated samples = 2800, effective sample size = 18
phase 31: number of correlated samples = 2800, effective sample size = 18
phase 32: number of correlated samples = 2800, effective sample size = 17
phase 33: number of correlated samples = 2800, effective sample size = 18
phase 34: number of correlated samples = 2800, effective sample size = 18
phase 35: number of correlated samples = 2800, effective sample size = 18
phase 36: number of correlated samples = 2800, effective sample size = 18
phase 37: number of correlated samples = 2800, effective sample size = 17
phase 38: number of correlated samples = 2800, effective sample size = 18
phase 39: number of correlated samples = 2800, effective sample size = 18
phase 40: number of correlated samples = 2800, effective sample size = 18
phase 41: number of correlated samples = 2800, effective sample size = 18
phase 42: number of correlated samples = 2800, effective sample size = 18
phase 43: number of correlated samples = 2800, effective sample size = 18
phase 44: number of correlated samples = 2800, effective sample size = 17
phase 45: number of correlated samples = 2800, effective sample size = 17
phase 46: number of correlated samples = 2800, effective sample size = 17
phase 47: number of correlated samples = 2800, effective sample size = 18
phase 48: number of correlated samples = 2800, effective sample size = 18
phase 49: number of correlated samples = 2800, effective sample size = 18
phase 50: number of correlated samples = 2800, effective sample size = 18
phase 51: number of correlated samples = 2800, effective sample size = 18
phase 52: number of correlated samples = 2800, effective sample size = 18
phase 53: number of correlated samples = 2800, effective sample size = 18
phase 54: number of correlated samples = 2800, effective sample size = 17
phase 55: number of correlated samples = 2800, effective sample size = 19
phase 56: number of correlated samples = 2800, effective sample size = 18
phase 57: number of correlated samples = 2800, effective sample size = 18
phase 58: number of correlated samples = 2800, effective sample size = 17
phase 59: number of correlated samples = 2800, effective sample size = 17
phase 60: number of correlated samples = 2800, effective sample size = 19
phase 61: number of correlated samples = 2800, effective sample size = 18
phase 62: number of correlated samples = 2800, effective sample size = 17
phase 63: number of correlated samples = 2800, effective sample size = 17
phase 64: number of correlated samples = 2800, effective sample size = 18
phase 65: number of correlated samples = 2800, effective sample size = 18
phase 66: number of correlated samples = 2800, effective sample size = 17
phase 67: number of correlated samples = 2800, effective sample size = 17
phase 68: number of correlated samples = 2800, effective sample size = 17
phase 69: number of correlated samples = 2800, effective sample size = 17
phase 70: number of correlated samples = 2800, effective sample size = 18
phase 71: number of correlated samples = 2800, effective sample size = 18
phase 72: number of correlated samples = 2800, effective sample size = 17
phase 73: number of correlated samples = 2800, effective sample size = 18
[5]total ess 1001: number of correlated samples = 160400
[5]maximum marginal PSRF: 1.01239


Segmentation fault (core dumped)
```
