### PR TITLE
solve issue #83: generate_steady_states fails when you edit a model's optimal percentage twice #83

### DIFF
--- a/dingo/gurobi_based_implementations.py
+++ b/dingo/gurobi_based_implementations.py
@@ -108,8 +108,9 @@ def fast_fba(lb, ub, S, c):
                     optimum_value = -model.getObjective().getValue()
                     v = model.getVars()
 
-                for i in range(n):
-                    optimum_sol.append(v[i].x)
+                    #  Access variable 'v' only if it is declared
+                    for i in range(n):
+                        optimum_sol.append(v[i].x)
 
                 optimum_sol = np.asarray(optimum_sol)
 


### PR DESCRIPTION
Apologies for any confusion—I just realized that I unintentionally deleted the repository (when I was creating a new fork for #89 ) from which I created the initial pull request, resulting in its closure. I've submitted a new pull request to address the same issue(https://github.com/GeomScale/dingo/pull/85). I appreciate your understanding and apologize for any inconvenience caused.
I am still working on this
