### PR TITLE
PreProcess class for reactions removal

### DIFF
--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -1,0 +1,148 @@
+
+from dingo import MetabolicNetwork
+import numpy as np
+import pandas as pd
+import cobra
+from cobra.io import load_json_model
+
+
+# function to load and benefit from both dingo's and cobrapy's model attributes
+def load_model(model):
+    dingo_model = MetabolicNetwork.from_json(model)
+    cobra_model = load_json_model(model)
+    return dingo_model, cobra_model
+
+dingo_model = load_model('e_coli_core.json')[0]
+cobra_model = load_model('e_coli_core.json')[1]
+
+
+# function to get a list of all reaction ids
+def reactions_ids(dingo_model):
+    reactions = dingo_model.reactions
+    return reactions
+
+reactions = reactions_ids(dingo_model)
+
+
+# function to find all unidirected reactions (-->)
+def unidirected_reactions(cobra_model):
+    uni_reactions = []
+    for reaction in reactions:
+        try:
+            str = cobra_model.reactions.get_by_id(reaction).reaction
+        except:
+            print("failed to find" , reaction)
+        
+        # continue if you find this arrow and not this <=>
+        try:
+            str.index("-->")
+            uni_reactions.append(reaction)   
+        except:
+            pass
+        
+    return uni_reactions
+
+uni_reactions = unidirected_reactions(cobra_model)
+
+
+# function to find metabolites participating in possible lumped reactions
+def lumped_metabolites(dingo_model):
+
+    stoichiometric_matrix = dingo_model.S
+    metabolites = dingo_model.metabolites
+    
+    positives = stoichiometric_matrix > 0
+    negatives = stoichiometric_matrix < 0
+    
+    exactly_one_positive = np.sum(positives, axis=1) == 1
+    exactly_one_negative = np.sum(negatives, axis=1) == 1
+    
+    # get boolean type array of rows where only one positive and one negative coefficient exists
+    matching_rows = np.logical_and(exactly_one_positive, exactly_one_negative)
+    
+    # get the corresponding rows indeces
+    lumped_met_index = np.where(matching_rows)[0]
+    
+    # get the corresponding metabolites ids
+    lumped_metabolites = []
+    for met in lumped_met_index:
+        lumped_metabolites.append(metabolites[met])
+        
+    # get the corresponding arrays rows
+    lumped_met_rows = stoichiometric_matrix[lumped_met_index]
+    
+    return lumped_metabolites, lumped_met_rows
+
+lumped_metabolites = lumped_metabolites(dingo_model)
+
+
+# function to find possible lumped reactions based on lumped metabolites
+def lumped_reactions(dingo_model):
+    
+    reactions = dingo_model.reactions
+    
+    # find reactions where lumped metabolites are substrates
+    columns_with_negatives = np.any(lumped_metabolites[1] < 0, axis=0)
+    lumped_reactions = [reactions[i] for i, has_negative in enumerate(columns_with_negatives) if has_negative]
+    
+    return lumped_reactions
+
+lumped_reactions = lumped_reactions(dingo_model)
+
+
+# function to match lumped reaction-substrate-product
+def lumped_reactions_substrate_product(cobra_model, lumped_reactions):
+        
+    # define some cofactors- this list must be updated
+    cofactors = [
+        "coa_c",
+        "atp_c",
+        "amp_c",
+        "adp_c",
+        "nad_c",
+        "nadh_c",
+        "nadp_c",
+        "nadph_c",
+        "h2o_c",
+        "h_c",
+        "accoa_c",
+        "h_e",
+        "co2_c",
+        "o2_c"]
+    
+    substrates = []
+    products = []
+    final_lumped_reactions = []
+
+    for lumped in lumped_reactions:
+        str = cobra_model.reactions.get_by_id(lumped).reaction 
+        try:
+            str.index("-->")
+            split = str.split(" ")
+            index = split.index("-->")
+            for substrate in split[0:index]:
+                # approach to remove coeeficients (1.0, 2.0)
+                try:
+                    float(substrate)
+                except:
+                    if substrate not in cofactors and (substrate != "+"):   
+                        substrates.append(substrate)
+            
+            for product in split[index+1:]:
+                try:
+                    float(product)
+                except:   
+                    if (product not in cofactors) and (product != "+"):
+                        products.append(product)
+                        
+            final_lumped_reactions.append(lumped)
+        except:
+            pass
+        
+    # find which product becomes substrate in another reaction
+    for i in range(len(products)):
+        if products[i] in substrates:
+            j = substrates.index(products[i])
+            print(final_lumped_reactions[i], "can be lumped with", final_lumped_reactions[j])
+                    
+reactions_substrates_products = lumped_reactions_substrate_product(cobra_model, lumped_reactions)

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -16,10 +16,13 @@ class PreProcess:
         model.reactions.get_by_id("BIOMASS_Ecoli_core_w_GAM").lower_bound = fba_solution.objective_value
 
         fva = cobra.flux_analysis.flux_variability_analysis(model, fraction_of_optimum=0.95)
-        blocked = cobra.flux_analysis.find_blocked_reactions(model)
-        return blocked
+        blocked_fva = fva.loc[(fva['minimum'] == 0) & (fva['maximum'] == 0)]
+        blocked_reactions = blocked_fva.index.tolist()
+        
+        return blocked_reactions
 
 
 model = load_json_model("../ext_data/e_coli_core.json")
 blocked = PreProcess.blocked_reactions(model)
 print(blocked)
+

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -177,10 +177,12 @@ class PreProcess:
         (b) The reduced dingo model
         """        
         
+        # create a list from the combined blocked, zero-flux, mle reactions
         blocked_mle_zero = self.blocked_reactions + self.mle_reactions + self.zero_flux_reactions
         list_removed_reactions = list(set(blocked_mle_zero))        
         self.removed_reactions = list_removed_reactions
    
+        # remove these reactions from the model
         self.remove_model_reactions()
                      
         remained_reactions = list((Counter(self.initial_reactions)-Counter(self.removed_reactions)).elements())
@@ -191,6 +193,7 @@ class PreProcess:
         if extend != 0 and extend != 1:
             raise Exception("Wrong Input to extend parameter")
   
+        # find additional reactions with a possibility of removal
         additional_removed_reactions_count = 0       
         for reaction in remained_reactions:
             
@@ -199,6 +202,7 @@ class PreProcess:
             initial_lower = self.model.reactions.get_by_id(reaction).lower_bound
             initial_upper = self.model.reactions.get_by_id(reaction).upper_bound
             
+            # perform a knock-out and check the output
             self.model.reactions.get_by_id(reaction).lower_bound = 0
             self.model.reactions.get_by_id(reaction).upper_bound = 0
     
@@ -213,6 +217,7 @@ class PreProcess:
             self.model.reactions.get_by_id(reaction).lower_bound = initial_lower
             
             
+        # compare FBA solution before and after the removal of additional reactions
         fba_solution_initial = self.model.optimize().objective_value
         self.remove_model_reactions()        
         fba_solution_final = self.model.optimize().objective_value
@@ -220,6 +225,8 @@ class PreProcess:
         
         additional_removed_reactions_list = (self.removed_reactions[len(self.removed_reactions)-additional_removed_reactions_count:])
         
+        # if FBA solution after removal is infesible or altered
+        # restore the initial reactions bounds
         if (fba_solution_final == None):
             for reaction in additional_removed_reactions_list:
                 self.model.reactions.get_by_id(reaction).bounds = self.reaction_bounds_dict[reaction]

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -8,11 +8,29 @@ class PreProcess:
     def __init__(self, model):
         self.model = model
         
+        
     def objective_function(model):
         
         objective = str(model.summary()._objective)
         objective = objective.split(" ")[1]
         return objective
+    
+
+    def zero_flux(model):
+        
+        tol = 1e-6
+        
+        fva = cobra.flux_analysis.flux_variability_analysis(model, fraction_of_optimum=0)
+        zero_flux = fva.loc[ (abs(fva['minimum']) < tol ) & (abs(fva['maximum']) < tol)]
+        zero_flux = zero_flux.index.tolist()
+        
+        return zero_flux
+    
+    
+    def blocked(model):
+        
+        return cobra.flux_analysis.find_blocked_reactions(model)
+    
 
     def metabolically_less_efficient(model):
         
@@ -23,17 +41,35 @@ class PreProcess:
         model.objective = objective
         fba_solution = model.optimize()
 
+        wt_lower_bound = model.reactions.get_by_id(objective).lower_bound
         model.reactions.get_by_id(objective).lower_bound = fba_solution.objective_value
 
         fva = cobra.flux_analysis.flux_variability_analysis(model, fraction_of_optimum=0.95)
-        blocked_fva = fva.loc[ (abs(fva['minimum']) < tol ) & (abs(fva['maximum']) < tol)]
-        mle = blocked_fva.index.tolist()
+        mle = fva.loc[ (abs(fva['minimum']) < tol ) & (abs(fva['maximum']) < tol)]
+        mle = mle.index.tolist()
+        
+        model.reactions.get_by_id(objective).lower_bound = wt_lower_bound
         
         return mle
+    
+    
+    def remove_from_model(model):
+
+        remove_reactions = []
+
+        blocked = PreProcess.blocked(model)
+        mle = PreProcess.metabolically_less_efficient(model)
+        zero_flux = PreProcess.zero_flux(model)
+
+        remove_reactions = blocked+mle+zero_flux
+        remove_reactions_unique = list(set(remove_reactions))
+        
+        return remove_reactions_unique
+        
 
 
 model = load_json_model("../ext_data/e_coli_core.json")
 
-blocked = PreProcess.metabolically_less_efficient(model)
-print(blocked)
+remove = PreProcess.remove_from_model(model)
+print(remove)
 

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -14,7 +14,7 @@ class PreProcess:
         objective = objective.split(" ")[1]
         return objective
 
-    def blocked_reactions(model):
+    def metabolically_less_efficient(model):
         
         objective = PreProcess.objective_function(model)
     
@@ -27,13 +27,13 @@ class PreProcess:
 
         fva = cobra.flux_analysis.flux_variability_analysis(model, fraction_of_optimum=0.95)
         blocked_fva = fva.loc[ (abs(fva['minimum']) < tol ) & (abs(fva['maximum']) < tol)]
-        blocked_reactions = blocked_fva.index.tolist()
+        mle = blocked_fva.index.tolist()
         
-        return blocked_reactions
+        return mle
 
 
 model = load_json_model("../ext_data/e_coli_core.json")
 
-blocked = PreProcess.blocked_reactions(model)
+blocked = PreProcess.metabolically_less_efficient(model)
 print(blocked)
 

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -82,7 +82,6 @@ class PreProcess:
 
     def possible_essential_reactions(model):
         
-        tol = 1e-6
         removed_reactions_list = PreProcess.list_removed_reactions(model)  
     
         # find model reactions
@@ -111,25 +110,25 @@ class PreProcess:
         final_possible_essential = []
 
         for reaction in possible_essential:
-            
-            fva = cobra.flux_analysis.flux_variability_analysis(model, fraction_of_optimum=0.9)
-            disabled_before = fva.loc[ (abs(fva['minimum']) < tol ) & (abs(fva['maximum']) < tol)]
-            disabled_before = len(disabled_before.index.tolist())
-            
+            print(reaction)
+                        
             initial_lower = model.reactions.get_by_id(reaction).lower_bound
             initial_upper = model.reactions.get_by_id(reaction).upper_bound
-                      
-            model.reactions.get_by_id(reaction).lower_bound = 0
-            model.reactions.get_by_id(reaction).upper_bound = 0
+            
+            fba_solution_before = model.optimize().objective_value
+
+            model.reactions.get_by_id(reaction).lower_bound = 0.01 * initial_lower
+            model.reactions.get_by_id(reaction).upper_bound = 0.01 * initial_upper
     
-            fva = cobra.flux_analysis.flux_variability_analysis(model, fraction_of_optimum=0.9)
-            disabled_after = fva.loc[ (abs(fva['minimum']) < tol ) & (abs(fva['maximum']) < tol)]
-            disabled_after = len(disabled_after.index.tolist())
+            fba_solution_after = model.optimize().objective_value
                                    
-            if disabled_before != disabled_after:
-                final_possible_essential.append(reaction)
-                model.reactions.get_by_id(reaction).upper_bound = initial_upper
-                model.reactions.get_by_id(reaction).lower_bound = initial_lower
+            if fba_solution_after < fba_solution_before:
+                if abs(fba_solution_before)-abs(fba_solution_after) > 0.3:
+                    final_possible_essential.append(reaction)
+                    
+            model.reactions.get_by_id(reaction).upper_bound = initial_upper
+            model.reactions.get_by_id(reaction).lower_bound = initial_lower
+            
             
         return final_possible_essential
         
@@ -140,12 +139,8 @@ model = load_json_model("../ext_data/e_coli_core.json")
 fba_solution = model.optimize()
 print(fba_solution.objective_value)
 
-#possible_essentials = PreProcess.possible_essential_reactions(model)
-#print(possible_essentials)
-
-model.reactions.get_by_id("PFK").lower_bound = 0
-model.reactions.get_by_id("PFK").upper_bound = 0
-
+possible_essentials = PreProcess.possible_essential_reactions(model)
+print(possible_essentials)
 
 fba_solution = model.optimize()
 print(fba_solution.objective_value)

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -82,8 +82,8 @@ class PreProcess:
 
     def possible_essential_reactions(model):
         
-        tol = 30.0
-        removed_reactions_list = PreProcess.list_removed_reactions(model)    
+        tol = 1e-6
+        removed_reactions_list = PreProcess.list_removed_reactions(model)  
     
         # find model reactions
         reactions_list = []
@@ -102,39 +102,52 @@ class PreProcess:
             essential_reactions_list.append(reaction_id)
             
         possible_essential = list((Counter(remained_reactions)-Counter(essential_reactions_list)).elements())
-        
         print(possible_essential)
+        
+        
+        PreProcess.remove_model_reactions(model)
+        
+        
         final_possible_essential = []
 
-        
         for reaction in possible_essential:
+            
+            fva = cobra.flux_analysis.flux_variability_analysis(model, fraction_of_optimum=0.9)
+            disabled_before = fva.loc[ (abs(fva['minimum']) < tol ) & (abs(fva['maximum']) < tol)]
+            disabled_before = len(disabled_before.index.tolist())
             
             initial_lower = model.reactions.get_by_id(reaction).lower_bound
             initial_upper = model.reactions.get_by_id(reaction).upper_bound
-                        
+                      
             model.reactions.get_by_id(reaction).lower_bound = 0
             model.reactions.get_by_id(reaction).upper_bound = 0
     
-            fva = cobra.flux_analysis.flux_variability_analysis(model, fraction_of_optimum=0.01)
-            active = fva.loc[ (abs(fva['minimum']) > tol ) & (abs(fva['maximum']) > tol)]
-            active = active.index.tolist()
-                        
-            model.reactions.get_by_id(reaction).upper_bound = initial_upper
-            model.reactions.get_by_id(reaction).lower_bound = initial_lower
-                        
-            if len(active) != 0:
+            fva = cobra.flux_analysis.flux_variability_analysis(model, fraction_of_optimum=0.9)
+            disabled_after = fva.loc[ (abs(fva['minimum']) < tol ) & (abs(fva['maximum']) < tol)]
+            disabled_after = len(disabled_after.index.tolist())
+                                   
+            if disabled_before != disabled_after:
                 final_possible_essential.append(reaction)
+                model.reactions.get_by_id(reaction).upper_bound = initial_upper
+                model.reactions.get_by_id(reaction).lower_bound = initial_lower
             
         return final_possible_essential
         
+
 
 model = load_json_model("../ext_data/e_coli_core.json")
 
 fba_solution = model.optimize()
 print(fba_solution.objective_value)
 
-possible_essentials = PreProcess.possible_essential_reactions(model)
-print(possible_essentials)
+#possible_essentials = PreProcess.possible_essential_reactions(model)
+#print(possible_essentials)
+
+model.reactions.get_by_id("PFK").lower_bound = 0
+model.reactions.get_by_id("PFK").upper_bound = 0
+
 
 fba_solution = model.optimize()
 print(fba_solution.objective_value)
+
+

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -9,20 +9,20 @@ class PreProcess:
     
     def __init__(self, model):
         self.model = model
-        self.objective = self.objective_function()
-        self.initial_reactions = self.initial()
-        self.reaction_bounds_dict = self.reaction_bounds_dictionary()
-        self.essential_reactions = self.essentials()
-        self.zero_flux_reactions = self.zero_flux()
-        self.blocked_reactions = self.blocked()
-        self.mle_reactions = self.metabolically_less_efficient()
-        self.dingo_model = self.cobra_dingo_conversion()
+        self.objective = self.__objective_function()
+        self.initial_reactions = self.__initial()
+        self.reaction_bounds_dict = self.__reaction_bounds_dictionary()
+        self.essential_reactions = self.__essentials()
+        self.zero_flux_reactions = self.__zero_flux()
+        self.blocked_reactions = self.__blocked()
+        self.mle_reactions = self.__metabolically_less_efficient()
+        self.dingo_tuple = self.__cobra_dingo_tuple()
         self.removed_reactions = []
 
         
-    def objective_function(self):
+    def __objective_function(self):
         """
-        A function  used to find the objective function of a model
+        A function used to find the objective function of a model
         """
         
         objective = str(self.model.summary()._objective)
@@ -32,7 +32,7 @@ class PreProcess:
         return self.objective
 
 
-    def initial(self):
+    def __initial(self):
         """
         A function used to find reaction ids of a model
         """
@@ -46,11 +46,11 @@ class PreProcess:
         return self.initial_reactions
     
     
-    def reaction_bounds_dictionary(self):
+    def __reaction_bounds_dictionary(self):
         """
         A function used to create a dictionary that maps
-        reactions with reactions bounds. It is used to
-        later restore some bounds to wild-type values
+        reactions with their corresponding bounds. It is used to
+        later restore bounds to their wild-type values
         """
         
         self.reaction_bounds_dict = {
@@ -64,10 +64,10 @@ class PreProcess:
         return self.reaction_bounds_dict
 
 
-    def essentials(self):
+    def __essentials(self):
         """
-        A function used to find all essential reactions
-        and appends them in a list
+        A function used to find all the essential reactions
+        and append them into a list
         """
         
         self.essential_reactions = []
@@ -79,11 +79,11 @@ class PreProcess:
         return self.essential_reactions
     
 
-    def zero_flux(self):
+    def __zero_flux(self):
         """
         A function used to find zero-flux reactions.
         These reactions are the ones that have a flux equaled to 0
-        when running FVA analysis with fraction of optimum set to 90%
+        when running a FVA analysis with the fraction of optimum set to 90%
         """
         
         tol = 1e-6
@@ -96,7 +96,7 @@ class PreProcess:
         return self.zero_flux_reactions
     
     
-    def blocked(self):
+    def __blocked(self):
         """
         A function used to find blocked reactions.
         These reactions can not have any flux other than 0
@@ -107,13 +107,12 @@ class PreProcess:
         return self.blocked_reactions
 
 
-    # to add documentation comments
-    def metabolically_less_efficient(self):
+    def __metabolically_less_efficient(self):
         """
         A function used to find metabolically less efficient reactions.
         These reactions are found when running an FBA and setting the  
         optimal growth rate as the lower bound of the objective function (in 
-        this case biomass production. After running an FVA with a fraction of optimum
+        this case biomass production. After running an FVA with the fraction of optimum
         set to 0.95, the reactions that have no flux are the metabolically less efficient.
         """
             
@@ -135,9 +134,9 @@ class PreProcess:
         return self.mle_reactions
     
     
-    def remove_model_reactions(self):
+    def __remove_model_reactions(self):
         """
-        A function used to set lower and upper bounds of certain reactions to 0
+        A function used to set the lower and upper bounds of certain reactions to 0
         (it turns off reactions)
         """
                                 
@@ -148,33 +147,41 @@ class PreProcess:
         return self.model
     
     
-    def cobra_dingo_conversion(self):
+    def __cobra_dingo_tuple(self):
         """
-        A function used to convert the reduced cobra model to a dingo model
+        A function used to convert the reduced cobra model to a dingo-type tuple
         """
-        self.dingo_model = parse_cobra_model(self.model)
-        return self.dingo_model
+        self.dingo_tuple = parse_cobra_model(self.model)
+        new_lb = self.dingo_tuple[0]
+        new_ub = self.dingo_tuple[1]
+        
+        return new_lb, new_ub
    
             
     def reduce(self, extend):
         """
-        A function that calls "remove_model_reactions" function
-        and removes blocked, zero-flux and metabolically less efficient reactions.
+        A function that calls the "remove_model_reactions" function
+        and removes blocked, zero-flux and metabolically less efficient 
+        reactions from the model.
+        
         Then it finds the remaining reactions in the model after 
         exclusion of the essential reactions.
         
-        The "extend" parameter when set to 1 performes an additional check to remove
-        further reactions. These reactions are the ones that if knocked-down, they
-        do not affect the value of the objective function. These reactions 
-        are removed simultaneously. If the simultaneous removal produces an infesible
-        solution (or 0) to the objective function, they are restored with their initial bounds.
+        When the "extend" parameter is set to 1, the function  performes
+        an additional check to remove further reactions. These reactions 
+        are the ones that if knocked-down, they do not affect the value 
+        of the objective function. These reactions are removed simultaneously
+        from the model. If this simultaneous removal produces an infesible
+        solution (or a solution of 0) to the objective function, 
+        these reactions are restored with their initial bounds.
         
-        The dingo model is then created from the cobra model 
-        using the "cobra_dingo_conversion" function.
+        A dingo-type tuple is then created from the cobra model 
+        using the "cobra_dingo_tuple" function.
         
         The outputs are
         (a) A list of the removed reactions ids
-        (b) The reduced dingo model
+        (b) The updated reactions lower bounds
+        (c) The updated reactions upper bounds
         """        
         
         # create a list from the combined blocked, zero-flux, mle reactions
@@ -183,7 +190,7 @@ class PreProcess:
         self.removed_reactions = list_removed_reactions
    
         # remove these reactions from the model
-        self.remove_model_reactions()
+        self.__remove_model_reactions()
                      
         remained_reactions = list((Counter(self.initial_reactions)-Counter(self.removed_reactions)).elements())
         remained_reactions = list((Counter(remained_reactions)-Counter(self.essential_reactions)).elements())
@@ -219,10 +226,11 @@ class PreProcess:
             
         # compare FBA solution before and after the removal of additional reactions
         fba_solution_initial = self.model.optimize().objective_value
-        self.remove_model_reactions()        
+        self.__remove_model_reactions()        
         fba_solution_final = self.model.optimize().objective_value
 
         
+        # get a list of the additional reactions to be removed
         additional_removed_reactions_list = (self.removed_reactions[len(self.removed_reactions)-additional_removed_reactions_count:])
         
         # if FBA solution after removal is infesible or altered
@@ -241,6 +249,9 @@ class PreProcess:
 
         else:
             print(len(self.removed_reactions), "of the", len(self.initial_reactions), "reactions were removed from the model with extend set to", extend)
-            
-        
-        return self.removed_reactions, self.cobra_dingo_conversion() 
+
+    
+        # call this functon to get updated bounds
+        new_lower_bounds, new_upper_bounds = self.__cobra_dingo_tuple()
+
+        return self.removed_reactions, new_lower_bounds, new_upper_bounds

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -2,19 +2,24 @@
 import cobra
 from cobra.io import load_json_model
 
+
+class PreProcess:
+    
+    def __init__(self, model):
+        self.model = model
+    
+    def blocked_reactions(model):
+
+        model.objective = 'BIOMASS_Ecoli_core_w_GAM'
+        fba_solution = model.optimize()
+
+        model.reactions.get_by_id("BIOMASS_Ecoli_core_w_GAM").lower_bound = fba_solution.objective_value
+
+        fva = cobra.flux_analysis.flux_variability_analysis(model, fraction_of_optimum=0.95)
+        blocked = cobra.flux_analysis.find_blocked_reactions(model)
+        return blocked
+
+
 model = load_json_model("../ext_data/e_coli_core.json")
-
-
-model.objective = 'BIOMASS_Ecoli_core_w_GAM'
-fba_solution = model.optimize()
-print(fba_solution.objective_value)
-
-
-model.reactions.get_by_id("BIOMASS_Ecoli_core_w_GAM").lower_bound = fba_solution.objective_value
-print(model.reactions.get_by_id("BIOMASS_Ecoli_core_w_GAM").lower_bound)
-print(model.reactions.get_by_id("BIOMASS_Ecoli_core_w_GAM").upper_bound)
-
-
-fva = cobra.flux_analysis.flux_variability_analysis(model, fraction_of_optimum=0.95)
-blocked = cobra.flux_analysis.find_blocked_reactions(model)
-print(len(blocked))
+blocked = PreProcess.blocked_reactions(model)
+print(blocked)

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -12,8 +12,8 @@ def load_model(model):
     cobra_model = load_json_model(model)
     return dingo_model, cobra_model
 
-dingo_model = load_model('e_coli_core.json')[0]
-cobra_model = load_model('e_coli_core.json')[1]
+dingo_model = load_model('../ext_data/e_coli_core.json')[0]
+cobra_model = load_model('../ext_data/e_coli_core.json')[1]
 
 
 # function to get a list of all reaction ids

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -9,128 +9,130 @@ class PreProcess:
     
     def __init__(self, model):
         self.model = model
+        self.objective = self.objective_function()
+        self.zero_flux_reactions = self.zero_flux()
+        self.blocked_reactions = self.blocked()
+        self.mle_reactions = self.metabolically_less_efficient()
+        self.removed_reactions = self.list_removed_reactions()
+        self.essential_reactions = self.possible_essential_reactions()
         
         
-    def objective_function(model):
+    def objective_function(self):
         
-        objective = str(model.summary()._objective)
+        objective = str(self.model.summary()._objective)
         objective = objective.split(" ")[1]
-        return objective
+        
+        self.objective = objective
+        return self.objective
     
 
-    def zero_flux(model):
+    def zero_flux(self):
         
         tol = 1e-6
         
-        fva = cobra.flux_analysis.flux_variability_analysis(model, fraction_of_optimum=0)
+        fva = cobra.flux_analysis.flux_variability_analysis(self.model, fraction_of_optimum=0.9)
         zero_flux = fva.loc[ (abs(fva['minimum']) < tol ) & (abs(fva['maximum']) < tol)]
-        zero_flux = zero_flux.index.tolist()
+        zero_flux_reactions = zero_flux.index.tolist()
         
-        return zero_flux
+        self.zero_flux_reactions = zero_flux_reactions
+        return self.zero_flux_reactions
     
     
-    def blocked(model):
+    def blocked(self):
         
-        return cobra.flux_analysis.find_blocked_reactions(model)
-    
+        blocked_reactions = cobra.flux_analysis.find_blocked_reactions(self.model)
+        self.blocked_reactions =  blocked_reactions
+        return self.blocked_reactions
 
-    def metabolically_less_efficient(model):
-        
-        objective = PreProcess.objective_function(model)
-    
+
+    # to add documentation comments
+    def metabolically_less_efficient(self):
+            
         tol = 1e-6
 
-        model.objective = objective
-        fba_solution = model.optimize()
+        self.model.objective = self.objective
+        fba_solution = self.model.optimize()
 
-        wt_lower_bound = model.reactions.get_by_id(objective).lower_bound
-        model.reactions.get_by_id(objective).lower_bound = fba_solution.objective_value
+        wt_lower_bound = self.model.reactions.get_by_id(self.objective).lower_bound
+        self.model.reactions.get_by_id(self.objective).lower_bound = fba_solution.objective_value
 
-        fva = cobra.flux_analysis.flux_variability_analysis(model, fraction_of_optimum=0.95)
+        fva = cobra.flux_analysis.flux_variability_analysis(self.model, fraction_of_optimum=0.95)
         mle = fva.loc[ (abs(fva['minimum']) < tol ) & (abs(fva['maximum']) < tol)]
         mle = mle.index.tolist()
         
-        model.reactions.get_by_id(objective).lower_bound = wt_lower_bound
+        self.model.reactions.get_by_id(self.objective).lower_bound = wt_lower_bound
         
-        return mle
+        self.mle_reactions = mle
+        return self.mle_reactions
     
     
-    def list_removed_reactions(model):
+    def list_removed_reactions(self):
 
         remove_reactions = []
 
-        blocked = PreProcess.blocked(model)
-        mle = PreProcess.metabolically_less_efficient(model)
-        zero_flux = PreProcess.zero_flux(model)
-
-        remove_reactions = blocked+mle+zero_flux
+        remove_reactions = self.blocked_reactions + self.mle_reactions + self.zero_flux_reactions
         list_removed_reactions = list(set(remove_reactions))
         
-        return list_removed_reactions
+        self.removed_reactions = list_removed_reactions
+        return self.removed_reactions
         
 
-    def remove_model_reactions(model):
-                
-        removed_reactions_list = PreProcess.list_removed_reactions(model)
-        
-        for reaction in removed_reactions_list:
-            model.reactions.get_by_id(reaction).lower_bound = 0
-            model.reactions.get_by_id(reaction).upper_bound = 0
+    def remove_model_reactions(self):
+                        
+        for reaction in self.removed_reactions:
+            self.model.reactions.get_by_id(reaction).lower_bound = 0
+            self.model.reactions.get_by_id(reaction).upper_bound = 0
             
-        return removed_reactions_list
+        return self.model
             
 
-    def possible_essential_reactions(model):
-        
-        removed_reactions_list = PreProcess.list_removed_reactions(model)  
-    
+    def possible_essential_reactions(self):
+            
         # find model reactions
         reactions_list = []
         
-        for reaction in model.reactions:
+        for reaction in self.model.reactions:
             reaction_id = reaction.id
             reactions_list.append(reaction_id)
             
-        remained_reactions = list((Counter(reactions_list)-Counter(removed_reactions_list)).elements())
+        remained_reactions = list((Counter(reactions_list)-Counter(self.removed_reactions)).elements())
    
         # find essential reactions
         essential_reactions_list = []
-        essential_reactions = cobra.flux_analysis.find_essential_reactions(model)
+        essential_reactions = cobra.flux_analysis.find_essential_reactions(self.model)
         for reaction in essential_reactions:
             reaction_id = reaction.id
             essential_reactions_list.append(reaction_id)
             
         possible_essential = list((Counter(remained_reactions)-Counter(essential_reactions_list)).elements())
-        print(possible_essential)
         
         
-        PreProcess.remove_model_reactions(model)
+        self.remove_model_reactions()
         
         
-        final_possible_essential = []
-
         for reaction in possible_essential:
-            print(reaction)
                         
-            initial_lower = model.reactions.get_by_id(reaction).lower_bound
-            initial_upper = model.reactions.get_by_id(reaction).upper_bound
+            initial_lower = self.model.reactions.get_by_id(reaction).lower_bound
+            initial_upper = self.model.reactions.get_by_id(reaction).upper_bound
             
-            fba_solution_before = model.optimize().objective_value
+            fba_solution_before = self.model.optimize().objective_value
 
-            model.reactions.get_by_id(reaction).lower_bound = 0.01 * initial_lower
-            model.reactions.get_by_id(reaction).upper_bound = 0.01 * initial_upper
+            self.model.reactions.get_by_id(reaction).lower_bound = 0.01 * initial_lower
+            self.model.reactions.get_by_id(reaction).upper_bound = 0.01 * initial_upper
     
-            fba_solution_after = model.optimize().objective_value
+            fba_solution_after = self.model.optimize().objective_value
                                    
             if fba_solution_after < fba_solution_before:
                 if abs(fba_solution_before)-abs(fba_solution_after) > 0.3:
-                    final_possible_essential.append(reaction)
+                    essential_reactions_list.append(reaction)
                     
-            model.reactions.get_by_id(reaction).upper_bound = initial_upper
-            model.reactions.get_by_id(reaction).lower_bound = initial_lower
+                    self.model.reactions.get_by_id(reaction).upper_bound = initial_upper
+                    self.model.reactions.get_by_id(reaction).lower_bound = initial_lower
             
             
-        return final_possible_essential
+        self.essential_reactions = essential_reactions_list
+        return self.essential_reactions
+        
         
 
 
@@ -139,8 +141,9 @@ model = load_json_model("../ext_data/e_coli_core.json")
 fba_solution = model.optimize()
 print(fba_solution.objective_value)
 
-possible_essentials = PreProcess.possible_essential_reactions(model)
-print(possible_essentials)
+obj = PreProcess(model)
+
+print(len(obj.essential_reactions))
 
 fba_solution = model.optimize()
 print(fba_solution.objective_value)

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -1,6 +1,7 @@
 
 import cobra
 from cobra.io import load_json_model
+import cobra.manipulation
 
 
 class PreProcess:
@@ -53,7 +54,7 @@ class PreProcess:
         return mle
     
     
-    def remove_from_model(model):
+    def list_removed_reactions(model):
 
         remove_reactions = []
 
@@ -62,14 +63,26 @@ class PreProcess:
         zero_flux = PreProcess.zero_flux(model)
 
         remove_reactions = blocked+mle+zero_flux
-        remove_reactions_unique = list(set(remove_reactions))
+        list_removed_reactions = list(set(remove_reactions))
         
-        return remove_reactions_unique
+        return list_removed_reactions
         
+
+    def remove_model_reactions(model):
+        
+        list_removed_reactions = PreProcess.list_removed_reactions(model)
+        
+        for reaction in list_removed_reactions:
+            model.reactions.get_by_id(reaction).lower_bound = 0
+            model.reactions.get_by_id(reaction).upper_bound = 0
 
 
 model = load_json_model("../ext_data/e_coli_core.json")
 
-remove = PreProcess.remove_from_model(model)
-print(remove)
+#fba_solution = model.optimize()
+#print(fba_solution.objective_value)
 
+new_model = PreProcess.remove_model_reactions(model)
+
+#fba_solution = model.optimize()
+#print(fba_solution.objective_value)

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -2,7 +2,7 @@
 import cobra
 from cobra.io import load_json_model
 
-model = load_json_model("e_coli_core.json")
+model = load_json_model("../ext_data/e_coli_core.json")
 
 
 model.objective = 'BIOMASS_Ecoli_core_w_GAM'

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -7,15 +7,23 @@ class PreProcess:
     
     def __init__(self, model):
         self.model = model
-    
+        
+    def objective_function(model):
+        
+        objective = str(model.summary()._objective)
+        objective = objective.split(" ")[1]
+        return objective
+
     def blocked_reactions(model):
         
+        objective = PreProcess.objective_function(model)
+    
         tol = 1e-6
 
-        model.objective = 'BIOMASS_Ecoli_core_w_GAM'
+        model.objective = objective
         fba_solution = model.optimize()
 
-        model.reactions.get_by_id("BIOMASS_Ecoli_core_w_GAM").lower_bound = fba_solution.objective_value
+        model.reactions.get_by_id(objective).lower_bound = fba_solution.objective_value
 
         fva = cobra.flux_analysis.flux_variability_analysis(model, fraction_of_optimum=0.95)
         blocked_fva = fva.loc[ (abs(fva['minimum']) < tol ) & (abs(fva['maximum']) < tol)]
@@ -25,6 +33,7 @@ class PreProcess:
 
 
 model = load_json_model("../ext_data/e_coli_core.json")
+
 blocked = PreProcess.blocked_reactions(model)
 print(blocked)
 

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -134,18 +134,19 @@ class PreProcess:
         return self.essential_reactions
         
         
-
+#if __name__ == "__main__":
+#    PreProcess()    
 
 model = load_json_model("../ext_data/e_coli_core.json")
 
-fba_solution = model.optimize()
-print(fba_solution.objective_value)
+#fba_solution = model.optimize()
+#print(fba_solution.objective_value)
 
 obj = PreProcess(model)
 
 print(len(obj.essential_reactions))
 
-fba_solution = model.optimize()
-print(fba_solution.objective_value)
+#fba_solution = model.optimize()
+#print(fba_solution.objective_value)
 
 

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -134,17 +134,17 @@ class PreProcess:
         return self.essential_reactions
         
         
-#if __name__ == "__main__":
-#    PreProcess()    
+if __name__ == "__main__":
+    PreProcess()    
 
-model = load_json_model("../ext_data/e_coli_core.json")
+#model = load_json_model("ext_data/e_coli_core.json")
 
 #fba_solution = model.optimize()
 #print(fba_solution.objective_value)
 
-obj = PreProcess(model)
+#obj = preprocess(model)
 
-print(len(obj.essential_reactions))
+#print(len(obj.essential_reactions))
 
 #fba_solution = model.optimize()
 #print(fba_solution.objective_value)

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -17,7 +17,6 @@ class PreProcess:
         self.mle_reactions = self.metabolically_less_efficient()
         self.removed_reactions = []
 
-
         
     def objective_function(self):
         """
@@ -40,6 +39,17 @@ class PreProcess:
             self.initial_reactions.append(reaction_id)
             
         return self.initial_reactions
+    
+    
+    def reaction_bounds_dictionary(self):
+        
+        self.reaction_bounds_dict = {
+                  'reaction': (0, 100)
+                  }
+                
+        for reaction_id in self.initial_reactions:
+            bounds = self.model.reactions.get_by_id(reaction_id).bounds
+            self.reaction_bounds_dict[reaction_id] = bounds
 
 
     def essentials(self):
@@ -103,17 +113,22 @@ class PreProcess:
     
     
     def remove_model_reactions(self):
-                        
+                                
         for reaction in self.removed_reactions:
             self.model.reactions.get_by_id(reaction).lower_bound = 0
             self.model.reactions.get_by_id(reaction).upper_bound = 0
             
         return self.model
-    
-            
-    def removed_reactions_ids(self):
         
-        #remove_reactions = []
+            
+    def removed(self, extend):
+        
+        tol = 1e-6
+        
+        if extend != 0 and extend != 1:
+            raise Exception("Wrong Input to extend parameter")
+        
+        
         blocked_mle_zero = self.blocked_reactions + self.mle_reactions + self.zero_flux_reactions
         list_removed_reactions = list(set(blocked_mle_zero))
         
@@ -122,10 +137,15 @@ class PreProcess:
         
         self.remove_model_reactions()
         
+                
         remained_reactions = list((Counter(self.initial_reactions)-Counter(self.removed_reactions)).elements())
         remained_reactions = list((Counter(remained_reactions)-Counter(self.essential_reactions)).elements())
    
+        additional_removed_reactions_count = 0
+        
         for reaction in remained_reactions:
+            
+            fba_solution_before = self.model.optimize().objective_value
                         
             initial_lower = self.model.reactions.get_by_id(reaction).lower_bound
             initial_upper = self.model.reactions.get_by_id(reaction).upper_bound
@@ -134,31 +154,53 @@ class PreProcess:
             self.model.reactions.get_by_id(reaction).upper_bound = 0
     
             fba_solution_after = self.model.optimize().objective_value
-            if (fba_solution_after == None) | (fba_solution_after == 0.0):
-                pass
-            else:
-                self.removed_reactions.append(reaction)
+            
+            if fba_solution_after != None and (extend == 1):
+                if (abs(fba_solution_after - fba_solution_before) < tol):
+                    self.removed_reactions.append(reaction)
+                    additional_removed_reactions_count += 1
               
             self.model.reactions.get_by_id(reaction).upper_bound = initial_upper
             self.model.reactions.get_by_id(reaction).lower_bound = initial_lower
             
             
-        self.remove_model_reactions()
-        print(len(self.removed_reactions), "of the", len(self.initial_reactions), "reactions were removed from the model")
+        fba_solution_initial = model.optimize().objective_value
+        self.remove_model_reactions()        
+        fba_solution_final = model.optimize().objective_value
+        
+        additional_removed_reactions_list = (self.removed_reactions[len(self.removed_reactions)-additional_removed_reactions_count:])
+        
+        if (fba_solution_final == None):
+            for reaction in additional_removed_reactions_list:
+                self.model.reactions.get_by_id(reaction).bounds = self.reaction_bounds_dict[reaction]
+                self.removed_reactions.remove(reaction)
+            print(len(self.removed_reactions), "of the", len(self.initial_reactions), "reactions were removed from the model")
+
+        elif(abs(fba_solution_final - fba_solution_initial) > tol):
+            for reaction in additional_removed_reactions_list:
+                self.model.reactions.get_by_id(reaction).bounds = self.reaction_bounds_dict[reaction]
+                self.removed_reactions.remove(reaction)
+            print(len(self.removed_reactions), "of the", len(self.initial_reactions), "reactions were removed from the model") 
+
+        else:
+            print(len(self.removed_reactions), "of the", len(self.initial_reactions), "reactions were removed from the model")      
+        
+        
         return self.removed_reactions
      
         
 
 model = load_json_model("ext_data/e_coli_core.json")
+model = load_json_model("../../../iAF1260.json")
 
-#fba_solution = model.optimize()
-#print(fba_solution.objective_value)
+fba_solution = model.optimize()
+print(fba_solution.objective_value)
 
 obj = PreProcess(model)
-rem = obj.removed_reactions_ids()
+rem = obj.removed(extend=1)
 print(len(rem))
 
-#fba_solution = model.optimize()
-#print(fba_solution.objective_value)
+fba_solution = model.optimize()
+print(fba_solution.objective_value)
 
 

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -7,9 +7,10 @@ from dingo import MetabolicNetwork
 
 class PreProcess:
     
-    def __init__(self, model):
+    def __init__(self, model, open_exchanges=False):
 
         self._model = model
+        self._open_exchanges = open_exchanges
         self._objective = self._objective_function()
         self._initial_reactions = self._initial()
         self._reaction_bounds_dict = self._reaction_bounds_dictionary()
@@ -26,9 +27,8 @@ class PreProcess:
         """
         
         objective = str(self._model.summary()._objective)
-        objective = objective.split(" ")[1]
+        self._objective = objective.split(" ")[1]
         
-        self._objective = objective
         return self._objective
 
 
@@ -37,12 +37,9 @@ class PreProcess:
         A function used to find reaction ids of a model
         """
         
-        self._initial_reactions = []
-        
-        for reaction in self._model.reactions:
-            reaction_id = reaction.id
-            self._initial_reactions.append(reaction_id)
-            
+        self._initial_reactions =  [ reaction.id for reaction in \
+        self._model.reactions ]
+                    
         return self._initial_reactions
     
     
@@ -53,9 +50,7 @@ class PreProcess:
         later restore bounds to their wild-type values
         """
         
-        self._reaction_bounds_dict = {
-                  'reaction': (0, 1000)
-                  }
+        self._reaction_bounds_dict = { }
                 
         for reaction_id in self._initial_reactions:
             bounds = self._model.reactions.get_by_id(reaction_id).bounds
@@ -67,22 +62,23 @@ class PreProcess:
     def _essentials(self):
         """
         A function used to find all the essential reactions
-        and append them into a list
+        and append them into a list. Essential reactions are
+        the ones that are required for growth. If removed the 
+        objective function gets zeroed.
         """
         
-        self._essential_reactions = []
-        essential_reactions = cobra.flux_analysis.find_essential_reactions(self._model)
-        for reaction in essential_reactions:
-            reaction_id = reaction.id
-            self._essential_reactions.append(reaction_id)
-            
+        self._essential_reactions =  [ reaction.id for reaction in \
+        cobra.flux_analysis.find_essential_reactions(self._model) ]
+                    
         return self._essential_reactions
     
 
     def _zero_flux(self):
         """
         A function used to find zero-flux reactions.
-        These reactions are the ones that have a flux equaled to 0
+        “Zero-flux” reactions cannot carry a flux while maintaining 
+        at least 90% of the maximum growth rate.
+        These reactions have both a min and a max flux equal to 0,
         when running a FVA analysis with the fraction of optimum set to 90%
         """
         
@@ -90,26 +86,26 @@ class PreProcess:
         
         fva = cobra.flux_analysis.flux_variability_analysis(self._model, fraction_of_optimum=0.9)
         zero_flux = fva.loc[ (abs(fva['minimum']) < tol ) & (abs(fva['maximum']) < tol)]
-        zero_flux_reactions = zero_flux.index.tolist()
+        self._zero_flux_reactions = zero_flux.index.tolist()
         
-        self._zero_flux_reactions = zero_flux_reactions
         return self._zero_flux_reactions
     
     
     def _blocked(self):
         """
         A function used to find blocked reactions.
+        "Blocked" reactions that cannot carry a flux in any condition.
         These reactions can not have any flux other than 0
         """
         
-        blocked_reactions = cobra.flux_analysis.find_blocked_reactions(self._model)
-        self._blocked_reactions =  blocked_reactions
+        self._blocked_reactions = cobra.flux_analysis.find_blocked_reactions(self._model, open_exchanges=self._open_exchanges)
         return self._blocked_reactions
 
 
     def _metabolically_less_efficient(self):
         """
         A function used to find metabolically less efficient reactions.
+        "Metabolically less efficient" require a reduction in growth rate if used
         These reactions are found when running an FBA and setting the  
         optimal growth rate as the lower bound of the objective function (in 
         this case biomass production. After running an FVA with the fraction of optimum
@@ -118,7 +114,6 @@ class PreProcess:
             
         tol = 1e-6
 
-        self._model.objective = self._objective
         fba_solution = self._model.optimize()
 
         wt_lower_bound = self._model.reactions.get_by_id(self._objective).lower_bound
@@ -126,11 +121,10 @@ class PreProcess:
 
         fva = cobra.flux_analysis.flux_variability_analysis(self._model, fraction_of_optimum=0.95)
         mle = fva.loc[ (abs(fva['minimum']) < tol ) & (abs(fva['maximum']) < tol)]
-        mle = mle.index.tolist()
+        self._mle_reactions = mle.index.tolist()
         
         self._model.reactions.get_by_id(self._objective).lower_bound = wt_lower_bound
         
-        self._mle_reactions = mle
         return self._mle_reactions
     
     
@@ -147,7 +141,7 @@ class PreProcess:
         return self._model
    
             
-    def reduce(self, extend):
+    def reduce(self, extend=False):
         """
         A function that calls the "remove_model_reactions" function
         and removes blocked, zero-flux and metabolically less efficient 
@@ -156,7 +150,7 @@ class PreProcess:
         Then it finds the remaining reactions in the model after 
         exclusion of the essential reactions.
         
-        When the "extend" parameter is set to 1, the function  performes
+        When the "extend" parameter is set to True, the function  performes
         an additional check to remove further reactions. These reactions 
         are the ones that if knocked-down, they do not affect the value 
         of the objective function. These reactions are removed simultaneously
@@ -185,61 +179,70 @@ class PreProcess:
         
         tol = 1e-6
         
-        if extend != 0 and extend != 1:
+        if extend != False and extend != True:
             raise Exception("Wrong Input to extend parameter")
+        
+        elif extend == False:
+            
+            print(len(self._removed_reactions), "of the", len(self._initial_reactions), \
+            "reactions were removed from the model with extend set to", extend) 
+            
+            # call this functon to convert cobra to dingo model
+            self._dingo_model = MetabolicNetwork.from_cobra_model(self._model)
+            return self._removed_reactions, self._dingo_model 
+
+        elif extend == True:
   
-        # find additional reactions with a possibility of removal
-        additional_removed_reactions_count = 0       
-        for reaction in remained_reactions:
+            # find additional reactions with a possibility of removal
+            additional_removed_reactions_list = []
+            additional_removed_reactions_count = 0       
+            for reaction in remained_reactions:
             
-            fba_solution_before = self._model.optimize().objective_value
-                        
-            initial_lower = self._model.reactions.get_by_id(reaction).lower_bound
-            initial_upper = self._model.reactions.get_by_id(reaction).upper_bound
+                fba_solution_before = self._model.optimize().objective_value
             
-            # perform a knock-out and check the output
-            self._model.reactions.get_by_id(reaction).lower_bound = 0
-            self._model.reactions.get_by_id(reaction).upper_bound = 0
+                # perform a knock-out and check the output
+                self._model.reactions.get_by_id(reaction).lower_bound = 0
+                self._model.reactions.get_by_id(reaction).upper_bound = 0
     
-            fba_solution_after = self._model.optimize().objective_value
+                fba_solution_after = self._model.optimize().objective_value
             
-            if fba_solution_after != None and (extend == 1):
-                if (abs(fba_solution_after - fba_solution_before) < tol):
-                    self._removed_reactions.append(reaction)
-                    additional_removed_reactions_count += 1
+                if fba_solution_after != None:
+                    if (abs(fba_solution_after - fba_solution_before) < tol):
+                        self._removed_reactions.append(reaction)
+                        additional_removed_reactions_list.append(reaction)
+                        additional_removed_reactions_count += 1
               
-            self._model.reactions.get_by_id(reaction).upper_bound = initial_upper
-            self._model.reactions.get_by_id(reaction).lower_bound = initial_lower
+                self._model.reactions.get_by_id(reaction).upper_bound = self._reaction_bounds_dict[reaction][1]
+                self._model.reactions.get_by_id(reaction).lower_bound = self._reaction_bounds_dict[reaction][0]
             
             
-        # compare FBA solution before and after the removal of additional reactions
-        fba_solution_initial = self._model.optimize().objective_value
-        self._remove_model_reactions()        
-        fba_solution_final = self._model.optimize().objective_value
+            # compare FBA solution before and after the removal of additional reactions
+            fba_solution_initial = self._model.optimize().objective_value
+            self._remove_model_reactions()        
+            fba_solution_final = self._model.optimize().objective_value
 
-        
-        # get a list of the additional reactions to be removed
-        additional_removed_reactions_list = (self._removed_reactions[len(self._removed_reactions)-additional_removed_reactions_count:])
-        
-        # if FBA solution after removal is infesible or altered
-        # restore the initial reactions bounds
-        if (fba_solution_final == None):
-            for reaction in additional_removed_reactions_list:
-                self._model.reactions.get_by_id(reaction).bounds = self._reaction_bounds_dict[reaction]
-                self._removed_reactions.remove(reaction)
-            print(len(self._removed_reactions), "of the", len(self._initial_reactions), "reactions were removed from the model with extend set to", extend)
+                
+            # if FBA solution after removal is infesible or altered
+            # restore the initial reactions bounds
+            if (fba_solution_final == None):
+                for reaction in additional_removed_reactions_list:
+                    self._model.reactions.get_by_id(reaction).bounds = self._reaction_bounds_dict[reaction]
+                    self._removed_reactions.remove(reaction)
+                print(len(self._removed_reactions), "of the", len(self._initial_reactions), \
+                "reactions were removed from the model with extend set to", extend)
 
-        elif(abs(fba_solution_final - fba_solution_initial) > tol):
-            for reaction in additional_removed_reactions_list:
-                self._model.reactions.get_by_id(reaction).bounds = self._reaction_bounds_dict[reaction]
-                self.removed_reactions.remove(reaction)
-            print(len(self._removed_reactions), "of the", len(self._initial_reactions), "reactions were removed from the model with extend set to", extend) 
+            elif(abs(fba_solution_final - fba_solution_initial) > tol):
+                for reaction in additional_removed_reactions_list:
+                    self._model.reactions.get_by_id(reaction).bounds = self._reaction_bounds_dict[reaction]
+                    self._removed_reactions.remove(reaction)
+                print(len(self._removed_reactions), "of the", len(self._initial_reactions), \
+                "reactions were removed from the model with extend set to", extend) 
 
-        else:
-            print(len(self._removed_reactions), "of the", len(self._initial_reactions), "reactions were removed from the model with extend set to", extend)
+            else:
+                print(len(self._removed_reactions), "of the", len(self._initial_reactions), \
+                "reactions were removed from the model with extend set to", extend)
 
     
-        # call this functon to convert cobra to dingo model
-        self._dingo_model = MetabolicNetwork.from_cobra_model(self._model)
-
-        return self._removed_reactions, self._dingo_model 
+            # call this functon to convert cobra to dingo model
+            self._dingo_model = MetabolicNetwork.from_cobra_model(self._model)
+            return self._removed_reactions, self._dingo_model 

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -24,27 +24,6 @@ def reactions_ids(dingo_model):
 reactions = reactions_ids(dingo_model)
 
 
-# function to find all unidirected reactions (-->)
-def unidirected_reactions(cobra_model):
-    uni_reactions = []
-    for reaction in reactions:
-        try:
-            str = cobra_model.reactions.get_by_id(reaction).reaction
-        except:
-            print("failed to find" , reaction)
-        
-        # continue if you find this arrow and not this <=>
-        try:
-            str.index("-->")
-            uni_reactions.append(reaction)   
-        except:
-            pass
-        
-    return uni_reactions
-
-uni_reactions = unidirected_reactions(cobra_model)
-
-
 # function to find metabolites participating in possible lumped reactions
 def lumped_metabolites(dingo_model):
 
@@ -117,7 +96,7 @@ def lumped_reactions_substrate_product(cobra_model, lumped_reactions):
     for lumped in lumped_reactions:
         str = cobra_model.reactions.get_by_id(lumped).reaction 
         try:
-            str.index("-->")
+            #str.index("-->")
             split = str.split(" ")
             index = split.index("-->")
             for substrate in split[0:index]:

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -10,23 +10,55 @@ class PreProcess:
     def __init__(self, model):
         self.model = model
         self.objective = self.objective_function()
+        self.initial_reactions = self.initial()
+        self.essential_reactions = self.essentials()
         self.zero_flux_reactions = self.zero_flux()
         self.blocked_reactions = self.blocked()
         self.mle_reactions = self.metabolically_less_efficient()
-        self.removed_reactions = self.list_removed_reactions()
-        self.essential_reactions = self.possible_essential_reactions()
-        
+        self.removed_reactions = []
+
+
         
     def objective_function(self):
+        """
+        A function  used to find the objective function of a model
+        """
         
         objective = str(self.model.summary()._objective)
         objective = objective.split(" ")[1]
         
         self.objective = objective
         return self.objective
+
+
+    def initial(self):
+        
+        self.initial_reactions = []
+        
+        for reaction in self.model.reactions:
+            reaction_id = reaction.id
+            self.initial_reactions.append(reaction_id)
+            
+        return self.initial_reactions
+
+
+    def essentials(self):
+        
+        self.essential_reactions = []
+        essential_reactions = cobra.flux_analysis.find_essential_reactions(self.model)
+        for reaction in essential_reactions:
+            reaction_id = reaction.id
+            self.essential_reactions.append(reaction_id)
+            
+        return self.essential_reactions
     
 
     def zero_flux(self):
+        """
+        A function used to find zero-flux reactions.
+        These reactions are the ones that have a flux equaled to 0
+        when running FVA analysis with fraction of optimum set to 90%
+        """
         
         tol = 1e-6
         
@@ -39,6 +71,10 @@ class PreProcess:
     
     
     def blocked(self):
+        """
+        A function used to find blocked reactions.
+        These reactions can not have any flux other than 0
+        """
         
         blocked_reactions = cobra.flux_analysis.find_blocked_reactions(self.model)
         self.blocked_reactions =  blocked_reactions
@@ -66,17 +102,6 @@ class PreProcess:
         return self.mle_reactions
     
     
-    def list_removed_reactions(self):
-
-        remove_reactions = []
-
-        remove_reactions = self.blocked_reactions + self.mle_reactions + self.zero_flux_reactions
-        list_removed_reactions = list(set(remove_reactions))
-        
-        self.removed_reactions = list_removed_reactions
-        return self.removed_reactions
-        
-
     def remove_model_reactions(self):
                         
         for reaction in self.removed_reactions:
@@ -84,67 +109,54 @@ class PreProcess:
             self.model.reactions.get_by_id(reaction).upper_bound = 0
             
         return self.model
+    
             
-
-    def possible_essential_reactions(self):
-            
-        # find model reactions
-        reactions_list = []
+    def removed_reactions_ids(self):
         
-        for reaction in self.model.reactions:
-            reaction_id = reaction.id
-            reactions_list.append(reaction_id)
-            
-        remained_reactions = list((Counter(reactions_list)-Counter(self.removed_reactions)).elements())
+        #remove_reactions = []
+        blocked_mle_zero = self.blocked_reactions + self.mle_reactions + self.zero_flux_reactions
+        list_removed_reactions = list(set(blocked_mle_zero))
+        
+        self.removed_reactions = list_removed_reactions
    
-        # find essential reactions
-        essential_reactions_list = []
-        essential_reactions = cobra.flux_analysis.find_essential_reactions(self.model)
-        for reaction in essential_reactions:
-            reaction_id = reaction.id
-            essential_reactions_list.append(reaction_id)
-            
-        possible_essential = list((Counter(remained_reactions)-Counter(essential_reactions_list)).elements())
-        
         
         self.remove_model_reactions()
         
-        
-        for reaction in possible_essential:
+        remained_reactions = list((Counter(self.initial_reactions)-Counter(self.removed_reactions)).elements())
+        remained_reactions = list((Counter(remained_reactions)-Counter(self.essential_reactions)).elements())
+   
+        for reaction in remained_reactions:
                         
             initial_lower = self.model.reactions.get_by_id(reaction).lower_bound
             initial_upper = self.model.reactions.get_by_id(reaction).upper_bound
             
-            fba_solution_before = self.model.optimize().objective_value
-
-            self.model.reactions.get_by_id(reaction).lower_bound = 0.01 * initial_lower
-            self.model.reactions.get_by_id(reaction).upper_bound = 0.01 * initial_upper
+            self.model.reactions.get_by_id(reaction).lower_bound = 0
+            self.model.reactions.get_by_id(reaction).upper_bound = 0
     
             fba_solution_after = self.model.optimize().objective_value
-                                   
-            if fba_solution_after < fba_solution_before:
-                if abs(fba_solution_before)-abs(fba_solution_after) > 0.3:
-                    essential_reactions_list.append(reaction)
-                    
-                    self.model.reactions.get_by_id(reaction).upper_bound = initial_upper
-                    self.model.reactions.get_by_id(reaction).lower_bound = initial_lower
+            if (fba_solution_after == None) | (fba_solution_after == 0.0):
+                pass
+            else:
+                self.removed_reactions.append(reaction)
+              
+            self.model.reactions.get_by_id(reaction).upper_bound = initial_upper
+            self.model.reactions.get_by_id(reaction).lower_bound = initial_lower
             
             
-        self.essential_reactions = essential_reactions_list
-        return self.essential_reactions
+        self.remove_model_reactions()
+        print(len(self.removed_reactions), "of the", len(self.initial_reactions), "reactions were removed from the model")
+        return self.removed_reactions
+     
         
-        
-if __name__ == "__main__":
-    PreProcess()    
 
-#model = load_json_model("ext_data/e_coli_core.json")
+model = load_json_model("ext_data/e_coli_core.json")
 
 #fba_solution = model.optimize()
 #print(fba_solution.objective_value)
 
-#obj = preprocess(model)
-
-#print(len(obj.essential_reactions))
+obj = PreProcess(model)
+rem = obj.removed_reactions_ids()
+print(len(rem))
 
 #fba_solution = model.optimize()
 #print(fba_solution.objective_value)

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -9,6 +9,8 @@ class PreProcess:
         self.model = model
     
     def blocked_reactions(model):
+        
+        tol = 1e-6
 
         model.objective = 'BIOMASS_Ecoli_core_w_GAM'
         fba_solution = model.optimize()
@@ -16,7 +18,7 @@ class PreProcess:
         model.reactions.get_by_id("BIOMASS_Ecoli_core_w_GAM").lower_bound = fba_solution.objective_value
 
         fva = cobra.flux_analysis.flux_variability_analysis(model, fraction_of_optimum=0.95)
-        blocked_fva = fva.loc[(fva['minimum'] == 0) & (fva['maximum'] == 0)]
+        blocked_fva = fva.loc[ (abs(fva['minimum']) < tol ) & (abs(fva['maximum']) < tol)]
         blocked_reactions = blocked_fva.index.tolist()
         
         return blocked_reactions

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -1,8 +1,8 @@
 
 import cobra
-from cobra.io import load_json_model
 import cobra.manipulation
 from collections import Counter
+from dingo.loading_models import parse_cobra_model
 
 
 class PreProcess:
@@ -11,6 +11,7 @@ class PreProcess:
         self.model = model
         self.objective = self.objective_function()
         self.initial_reactions = self.initial()
+        self.reaction_bounds_dict = self.reaction_bounds_dictionary()
         self.essential_reactions = self.essentials()
         self.zero_flux_reactions = self.zero_flux()
         self.blocked_reactions = self.blocked()
@@ -31,6 +32,9 @@ class PreProcess:
 
 
     def initial(self):
+        """
+        A function used to find reaction ids of a model
+        """
         
         self.initial_reactions = []
         
@@ -42,6 +46,11 @@ class PreProcess:
     
     
     def reaction_bounds_dictionary(self):
+        """
+        A function used to create a dictionary that maps
+        reactions with reactions bounds. It is used to
+        later restore some bounds to wild-type values
+        """
         
         self.reaction_bounds_dict = {
                   'reaction': (0, 100)
@@ -50,9 +59,15 @@ class PreProcess:
         for reaction_id in self.initial_reactions:
             bounds = self.model.reactions.get_by_id(reaction_id).bounds
             self.reaction_bounds_dict[reaction_id] = bounds
+            
+        return self.reaction_bounds_dict
 
 
     def essentials(self):
+        """
+        A function used to find all essential reactions
+        and appends them in a list
+        """
         
         self.essential_reactions = []
         essential_reactions = cobra.flux_analysis.find_essential_reactions(self.model)
@@ -93,6 +108,13 @@ class PreProcess:
 
     # to add documentation comments
     def metabolically_less_efficient(self):
+        """
+        A function used to find metabolically less efficient reactions.
+        These reactions are found when running an FBA and setting the  
+        optimal growth rate as the lower bound of the objective function (in 
+        this case biomass production. After running an FVA with a fraction of optimum
+        set to 0.95, the reactions that have no flux are the metabolically less efficient.
+        """
             
         tol = 1e-6
 
@@ -113,6 +135,10 @@ class PreProcess:
     
     
     def remove_model_reactions(self):
+        """
+        A function used to set lower and upper bounds of certain reactions to 0
+        (it turns off reactions)
+        """
                                 
         for reaction in self.removed_reactions:
             self.model.reactions.get_by_id(reaction).lower_bound = 0
@@ -122,27 +148,34 @@ class PreProcess:
         
             
     def removed(self, extend):
+        """
+        A function that calls "remove_model_reactions" function
+        and removes blocked, zero-flux and metabolically less efficient reactions.
+        Then it finds the remaining reactions in the model after 
+        exclusion of the essential reactions.
+        
+        The "extend" parameter when set to 1 performes an additional check to remove
+        further reactions. These reactions are the ones that if knocked-down, they
+        do not affect the value of the objective function. These reactions 
+        are removed simultaneously. If the simultaneous removal produces an infesible
+        solution (or 0) to the objective function, they are restored with their initial bounds.
+        """        
+        
+        blocked_mle_zero = self.blocked_reactions + self.mle_reactions + self.zero_flux_reactions
+        list_removed_reactions = list(set(blocked_mle_zero))        
+        self.removed_reactions = list_removed_reactions
+   
+        self.remove_model_reactions()
+                     
+        remained_reactions = list((Counter(self.initial_reactions)-Counter(self.removed_reactions)).elements())
+        remained_reactions = list((Counter(remained_reactions)-Counter(self.essential_reactions)).elements())
         
         tol = 1e-6
         
         if extend != 0 and extend != 1:
             raise Exception("Wrong Input to extend parameter")
-        
-        
-        blocked_mle_zero = self.blocked_reactions + self.mle_reactions + self.zero_flux_reactions
-        list_removed_reactions = list(set(blocked_mle_zero))
-        
-        self.removed_reactions = list_removed_reactions
-   
-        
-        self.remove_model_reactions()
-        
-                
-        remained_reactions = list((Counter(self.initial_reactions)-Counter(self.removed_reactions)).elements())
-        remained_reactions = list((Counter(remained_reactions)-Counter(self.essential_reactions)).elements())
-   
-        additional_removed_reactions_count = 0
-        
+  
+        additional_removed_reactions_count = 0       
         for reaction in remained_reactions:
             
             fba_solution_before = self.model.optimize().objective_value
@@ -164,9 +197,10 @@ class PreProcess:
             self.model.reactions.get_by_id(reaction).lower_bound = initial_lower
             
             
-        fba_solution_initial = model.optimize().objective_value
+        fba_solution_initial = self.model.optimize().objective_value
         self.remove_model_reactions()        
-        fba_solution_final = model.optimize().objective_value
+        fba_solution_final = self.model.optimize().objective_value
+
         
         additional_removed_reactions_list = (self.removed_reactions[len(self.removed_reactions)-additional_removed_reactions_count:])
         
@@ -174,33 +208,24 @@ class PreProcess:
             for reaction in additional_removed_reactions_list:
                 self.model.reactions.get_by_id(reaction).bounds = self.reaction_bounds_dict[reaction]
                 self.removed_reactions.remove(reaction)
-            print(len(self.removed_reactions), "of the", len(self.initial_reactions), "reactions were removed from the model")
+            print(len(self.removed_reactions), "of the", len(self.initial_reactions), "reactions were removed from the model with extend set to", extend)
 
         elif(abs(fba_solution_final - fba_solution_initial) > tol):
             for reaction in additional_removed_reactions_list:
                 self.model.reactions.get_by_id(reaction).bounds = self.reaction_bounds_dict[reaction]
                 self.removed_reactions.remove(reaction)
-            print(len(self.removed_reactions), "of the", len(self.initial_reactions), "reactions were removed from the model") 
+            print(len(self.removed_reactions), "of the", len(self.initial_reactions), "reactions were removed from the model with extend set to", extend) 
 
         else:
-            print(len(self.removed_reactions), "of the", len(self.initial_reactions), "reactions were removed from the model")      
-        
+            print(len(self.removed_reactions), "of the", len(self.initial_reactions), "reactions were removed from the model with extend set to", extend)      
         
         return self.removed_reactions
-     
-        
-
-model = load_json_model("ext_data/e_coli_core.json")
-model = load_json_model("../../../iAF1260.json")
-
-fba_solution = model.optimize()
-print(fba_solution.objective_value)
-
-obj = PreProcess(model)
-rem = obj.removed(extend=1)
-print(len(rem))
-
-fba_solution = model.optimize()
-print(fba_solution.objective_value)
-
+    
+    
+    def dingo_model_conversion(self):
+        """
+        A function used to convert the reduced cobra model to a dingo model
+        """
+        dingo_model = parse_cobra_model(self.model)
+        return dingo_model
 

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -2,6 +2,7 @@
 import cobra
 from cobra.io import load_json_model
 import cobra.manipulation
+from collections import Counter
 
 
 class PreProcess:
@@ -69,20 +70,71 @@ class PreProcess:
         
 
     def remove_model_reactions(model):
+                
+        removed_reactions_list = PreProcess.list_removed_reactions(model)
         
-        list_removed_reactions = PreProcess.list_removed_reactions(model)
-        
-        for reaction in list_removed_reactions:
+        for reaction in removed_reactions_list:
             model.reactions.get_by_id(reaction).lower_bound = 0
             model.reactions.get_by_id(reaction).upper_bound = 0
+            
+        return removed_reactions_list
+            
 
+    def possible_essential_reactions(model):
+        
+        tol = 30.0
+        removed_reactions_list = PreProcess.list_removed_reactions(model)    
+    
+        # find model reactions
+        reactions_list = []
+        
+        for reaction in model.reactions:
+            reaction_id = reaction.id
+            reactions_list.append(reaction_id)
+            
+        remained_reactions = list((Counter(reactions_list)-Counter(removed_reactions_list)).elements())
+   
+        # find essential reactions
+        essential_reactions_list = []
+        essential_reactions = cobra.flux_analysis.find_essential_reactions(model)
+        for reaction in essential_reactions:
+            reaction_id = reaction.id
+            essential_reactions_list.append(reaction_id)
+            
+        possible_essential = list((Counter(remained_reactions)-Counter(essential_reactions_list)).elements())
+        
+        print(possible_essential)
+        final_possible_essential = []
+
+        
+        for reaction in possible_essential:
+            
+            initial_lower = model.reactions.get_by_id(reaction).lower_bound
+            initial_upper = model.reactions.get_by_id(reaction).upper_bound
+                        
+            model.reactions.get_by_id(reaction).lower_bound = 0
+            model.reactions.get_by_id(reaction).upper_bound = 0
+    
+            fva = cobra.flux_analysis.flux_variability_analysis(model, fraction_of_optimum=0.01)
+            active = fva.loc[ (abs(fva['minimum']) > tol ) & (abs(fva['maximum']) > tol)]
+            active = active.index.tolist()
+                        
+            model.reactions.get_by_id(reaction).upper_bound = initial_upper
+            model.reactions.get_by_id(reaction).lower_bound = initial_lower
+                        
+            if len(active) != 0:
+                final_possible_essential.append(reaction)
+            
+        return final_possible_essential
+        
 
 model = load_json_model("../ext_data/e_coli_core.json")
 
-#fba_solution = model.optimize()
-#print(fba_solution.objective_value)
+fba_solution = model.optimize()
+print(fba_solution.objective_value)
 
-new_model = PreProcess.remove_model_reactions(model)
+possible_essentials = PreProcess.possible_essential_reactions(model)
+print(possible_essentials)
 
-#fba_solution = model.optimize()
-#print(fba_solution.objective_value)
+fba_solution = model.optimize()
+print(fba_solution.objective_value)

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -7,10 +7,27 @@ from dingo import MetabolicNetwork
 
 class PreProcess:
     
-    def __init__(self, model, open_exchanges=False):
+    def __init__(self, model, tol=1e-6, open_exchanges=False):
 
+        """
+        model parameter gets a cobra model as input
+        
+        tol parameter gets a cutoff value used to classify 
+        zero-flux and mle reactions and compare FBA solutions
+        before and after reactions removal
+        
+        open_exchanges parameter is used in the function that identifies blocked reactions
+        It controls whether or not to open all exchange reactions to very high flux ranges
+        """
+        
         self._model = model
+        self._tol = tol
+        
+        if self._tol > 1e-6:
+            print("Tolerance value set to",self._tol,"while default value is 1e-6. A looser check will be performed")
+        
         self._open_exchanges = open_exchanges
+        
         self._objective = self._objective_function()
         self._initial_reactions = self._initial()
         self._reaction_bounds_dict = self._reaction_bounds_dictionary()
@@ -82,7 +99,7 @@ class PreProcess:
         when running a FVA analysis with the fraction of optimum set to 90%
         """
         
-        tol = 1e-6
+        tol = self._tol
         
         fva = cobra.flux_analysis.flux_variability_analysis(self._model, fraction_of_optimum=0.9)
         zero_flux = fva.loc[ (abs(fva['minimum']) < tol ) & (abs(fva['maximum']) < tol)]
@@ -112,7 +129,7 @@ class PreProcess:
         set to 0.95, the reactions that have no flux are the metabolically less efficient.
         """
             
-        tol = 1e-6
+        tol = self._tol
 
         fba_solution = self._model.optimize()
 
@@ -177,7 +194,7 @@ class PreProcess:
         remained_reactions = list((Counter(self._initial_reactions)-Counter(self._removed_reactions)).elements())
         remained_reactions = list((Counter(remained_reactions)-Counter(self._essential_reactions)).elements())
         
-        tol = 1e-6
+        tol = self._tol
         
         if extend != False and extend != True:
             raise Exception("Wrong Input to extend parameter")
@@ -222,21 +239,14 @@ class PreProcess:
             fba_solution_final = self._model.optimize().objective_value
 
                 
-            # if FBA solution after removal is infesible or altered
+            # if FBA solution after removal is infeasible or altered
             # restore the initial reactions bounds
-            if (fba_solution_final == None):
+            if (fba_solution_final == None) | (abs(fba_solution_final - fba_solution_initial) > tol):
                 for reaction in additional_removed_reactions_list:
                     self._model.reactions.get_by_id(reaction).bounds = self._reaction_bounds_dict[reaction]
                     self._removed_reactions.remove(reaction)
                 print(len(self._removed_reactions), "of the", len(self._initial_reactions), \
                 "reactions were removed from the model with extend set to", extend)
-
-            elif(abs(fba_solution_final - fba_solution_initial) > tol):
-                for reaction in additional_removed_reactions_list:
-                    self._model.reactions.get_by_id(reaction).bounds = self._reaction_bounds_dict[reaction]
-                    self._removed_reactions.remove(reaction)
-                print(len(self._removed_reactions), "of the", len(self._initial_reactions), \
-                "reactions were removed from the model with extend set to", extend) 
 
             else:
                 print(len(self._removed_reactions), "of the", len(self._initial_reactions), \

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -1,123 +1,20 @@
 
-from dingo import MetabolicNetwork
-import numpy as np
-import pandas as pd
 import cobra
 from cobra.io import load_json_model
 
-
-# function to load and benefit from both dingo's and cobrapy's model attributes
-def load_model(model):
-    dingo_model = MetabolicNetwork.from_json(model)
-    cobra_model = load_json_model(model)
-    return dingo_model, cobra_model
-
-dingo_model = load_model('../ext_data/e_coli_core.json')[0]
-cobra_model = load_model('../ext_data/e_coli_core.json')[1]
+model = load_json_model("e_coli_core.json")
 
 
-# function to get a list of all reaction ids
-def reactions_ids(dingo_model):
-    reactions = dingo_model.reactions
-    return reactions
+model.objective = 'BIOMASS_Ecoli_core_w_GAM'
+fba_solution = model.optimize()
+print(fba_solution.objective_value)
 
 
-# function to find metabolites participating in possible lumped reactions
-def lumped_metabolites(dingo_model):
-
-    stoichiometric_matrix = dingo_model.S
-    metabolites = dingo_model.metabolites
-    
-    positives = stoichiometric_matrix > 0
-    negatives = stoichiometric_matrix < 0
-    
-    exactly_one_positive = np.sum(positives, axis=1) == 1
-    exactly_one_negative = np.sum(negatives, axis=1) == 1
-    
-    # get boolean type array of rows where only one positive and one negative coefficient exists
-    matching_rows = np.logical_and(exactly_one_positive, exactly_one_negative)
-    
-    # get the corresponding rows indeces
-    lumped_met_index = np.where(matching_rows)[0]
-    
-    # get the corresponding metabolites ids
-    lumped_metabolites = []
-    for met in lumped_met_index:
-        lumped_metabolites.append(metabolites[met])
-        
-    # get the corresponding arrays rows
-    lumped_met_rows = stoichiometric_matrix[lumped_met_index]
-    
-    return lumped_metabolites, lumped_met_rows
+model.reactions.get_by_id("BIOMASS_Ecoli_core_w_GAM").lower_bound = fba_solution.objective_value
+print(model.reactions.get_by_id("BIOMASS_Ecoli_core_w_GAM").lower_bound)
+print(model.reactions.get_by_id("BIOMASS_Ecoli_core_w_GAM").upper_bound)
 
 
-# function to find possible lumped reactions based on lumped metabolites
-def lumped_reactions(dingo_model):
-    
-    reactions = reactions_ids(dingo_model)
-    
-    # find reactions where lumped metabolites are substrates
-    columns_with_negatives = np.any(lumped_metabolites(dingo_model)[1] < 0, axis=0)
-    lumped_reactions = [reactions[i] for i, has_negative in enumerate(columns_with_negatives) if has_negative]
-    
-    return lumped_reactions
-
-lumped_reactions = lumped_reactions(dingo_model)
-
-
-# function to match lumped reaction-substrate-product
-def lumped_reactions_substrate_product(cobra_model, lumped_reactions):
-    
-    # define some cofactors- this list must be updated
-    cofactors = [
-        "coa_c",
-        "atp_c",
-        "amp_c",
-        "adp_c",
-        "nad_c",
-        "nadh_c",
-        "nadp_c",
-        "nadph_c",
-        "h2o_c",
-        "h_c",
-        "accoa_c",
-        "h_e",
-        "co2_c",
-        "o2_c"]
-    
-    substrates = []
-    products = []
-    final_lumped_reactions = []
-
-    for lumped in lumped_reactions:
-        str = cobra_model.reactions.get_by_id(lumped).reaction 
-        try:
-            str.index("-->")
-            split = str.split(" ")
-            index = split.index("-->")
-            for substrate in split[0:index]:
-                # approach to remove coeeficients (1.0, 2.0)
-                try:
-                    float(substrate)
-                except:
-                    if substrate not in cofactors and (substrate != "+"):   
-                        substrates.append(substrate)
-            
-            for product in split[index+1:]:
-                try:
-                    float(product)
-                except:   
-                    if (product not in cofactors) and (product != "+"):
-                        products.append(product)
-                        
-            final_lumped_reactions.append(lumped)
-        except:
-            pass
-        
-    # find which product becomes substrate in another reaction
-    for i in range(len(products)):
-        if products[i] in substrates:
-            j = substrates.index(products[i])
-            print(final_lumped_reactions[i], "can be lumped with", final_lumped_reactions[j])
-                    
-reactions_substrates_products = lumped_reactions_substrate_product(cobra_model, lumped_reactions)
+fva = cobra.flux_analysis.flux_variability_analysis(model, fraction_of_optimum=0.95)
+blocked = cobra.flux_analysis.find_blocked_reactions(model)
+print(len(blocked))

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -21,8 +21,6 @@ def reactions_ids(dingo_model):
     reactions = dingo_model.reactions
     return reactions
 
-reactions = reactions_ids(dingo_model)
-
 
 # function to find metabolites participating in possible lumped reactions
 def lumped_metabolites(dingo_model):
@@ -52,16 +50,14 @@ def lumped_metabolites(dingo_model):
     
     return lumped_metabolites, lumped_met_rows
 
-lumped_metabolites = lumped_metabolites(dingo_model)
-
 
 # function to find possible lumped reactions based on lumped metabolites
 def lumped_reactions(dingo_model):
     
-    reactions = dingo_model.reactions
+    reactions = reactions_ids(dingo_model)
     
     # find reactions where lumped metabolites are substrates
-    columns_with_negatives = np.any(lumped_metabolites[1] < 0, axis=0)
+    columns_with_negatives = np.any(lumped_metabolites(dingo_model)[1] < 0, axis=0)
     lumped_reactions = [reactions[i] for i, has_negative in enumerate(columns_with_negatives) if has_negative]
     
     return lumped_reactions
@@ -71,7 +67,7 @@ lumped_reactions = lumped_reactions(dingo_model)
 
 # function to match lumped reaction-substrate-product
 def lumped_reactions_substrate_product(cobra_model, lumped_reactions):
-        
+    
     # define some cofactors- this list must be updated
     cofactors = [
         "coa_c",
@@ -96,7 +92,7 @@ def lumped_reactions_substrate_product(cobra_model, lumped_reactions):
     for lumped in lumped_reactions:
         str = cobra_model.reactions.get_by_id(lumped).reaction 
         try:
-            #str.index("-->")
+            str.index("-->")
             split = str.split(" ")
             index = split.index("-->")
             for substrate in split[0:index]:

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -2,84 +2,84 @@
 import cobra
 import cobra.manipulation
 from collections import Counter
-from dingo.loading_models import parse_cobra_model
+from dingo import MetabolicNetwork
 
 
 class PreProcess:
     
     def __init__(self, model):
-        self.model = model
-        self.objective = self.__objective_function()
-        self.initial_reactions = self.__initial()
-        self.reaction_bounds_dict = self.__reaction_bounds_dictionary()
-        self.essential_reactions = self.__essentials()
-        self.zero_flux_reactions = self.__zero_flux()
-        self.blocked_reactions = self.__blocked()
-        self.mle_reactions = self.__metabolically_less_efficient()
-        self.dingo_tuple = self.__cobra_dingo_tuple()
-        self.removed_reactions = []
 
-        
-    def __objective_function(self):
+        self._model = model
+        self._objective = self._objective_function()
+        self._initial_reactions = self._initial()
+        self._reaction_bounds_dict = self._reaction_bounds_dictionary()
+        self._essential_reactions = self._essentials()
+        self._zero_flux_reactions = self._zero_flux()
+        self._blocked_reactions = self._blocked()
+        self._mle_reactions = self._metabolically_less_efficient()
+        self._removed_reactions = []
+
+
+    def _objective_function(self):
         """
         A function used to find the objective function of a model
         """
         
-        objective = str(self.model.summary()._objective)
+        objective = str(self._model.summary()._objective)
         objective = objective.split(" ")[1]
         
-        self.objective = objective
-        return self.objective
+        self._objective = objective
+        return self._objective
 
 
-    def __initial(self):
+    def _initial(self):
         """
         A function used to find reaction ids of a model
         """
         
-        self.initial_reactions = []
+        self._initial_reactions = []
         
-        for reaction in self.model.reactions:
+        for reaction in self._model.reactions:
             reaction_id = reaction.id
-            self.initial_reactions.append(reaction_id)
+            self._initial_reactions.append(reaction_id)
             
-        return self.initial_reactions
+        return self._initial_reactions
     
     
-    def __reaction_bounds_dictionary(self):
+    def _reaction_bounds_dictionary(self):
         """
         A function used to create a dictionary that maps
         reactions with their corresponding bounds. It is used to
         later restore bounds to their wild-type values
         """
         
-        self.reaction_bounds_dict = {
-                  'reaction': (0, 100)
+        self._reaction_bounds_dict = {
+                  'reaction': (0, 1000)
                   }
                 
-        for reaction_id in self.initial_reactions:
-            bounds = self.model.reactions.get_by_id(reaction_id).bounds
-            self.reaction_bounds_dict[reaction_id] = bounds
+        for reaction_id in self._initial_reactions:
+            bounds = self._model.reactions.get_by_id(reaction_id).bounds
+            self._reaction_bounds_dict[reaction_id] = bounds
             
-        return self.reaction_bounds_dict
+        return self._reaction_bounds_dict
 
 
-    def __essentials(self):
+    def _essentials(self):
         """
         A function used to find all the essential reactions
         and append them into a list
         """
         
-        self.essential_reactions = []
-        essential_reactions = cobra.flux_analysis.find_essential_reactions(self.model)
+        self._essential_reactions = []
+        essential_reactions = cobra.flux_analysis.find_essential_reactions(self._model)
         for reaction in essential_reactions:
             reaction_id = reaction.id
-            self.essential_reactions.append(reaction_id)
+            self._essential_reactions.append(reaction_id)
             
-        return self.essential_reactions
+        return self._essential_reactions
     
 
-    def __zero_flux(self):
+    def _zero_flux(self):
         """
         A function used to find zero-flux reactions.
         These reactions are the ones that have a flux equaled to 0
@@ -88,26 +88,26 @@ class PreProcess:
         
         tol = 1e-6
         
-        fva = cobra.flux_analysis.flux_variability_analysis(self.model, fraction_of_optimum=0.9)
+        fva = cobra.flux_analysis.flux_variability_analysis(self._model, fraction_of_optimum=0.9)
         zero_flux = fva.loc[ (abs(fva['minimum']) < tol ) & (abs(fva['maximum']) < tol)]
         zero_flux_reactions = zero_flux.index.tolist()
         
-        self.zero_flux_reactions = zero_flux_reactions
-        return self.zero_flux_reactions
+        self._zero_flux_reactions = zero_flux_reactions
+        return self._zero_flux_reactions
     
     
-    def __blocked(self):
+    def _blocked(self):
         """
         A function used to find blocked reactions.
         These reactions can not have any flux other than 0
         """
         
-        blocked_reactions = cobra.flux_analysis.find_blocked_reactions(self.model)
-        self.blocked_reactions =  blocked_reactions
-        return self.blocked_reactions
+        blocked_reactions = cobra.flux_analysis.find_blocked_reactions(self._model)
+        self._blocked_reactions =  blocked_reactions
+        return self._blocked_reactions
 
 
-    def __metabolically_less_efficient(self):
+    def _metabolically_less_efficient(self):
         """
         A function used to find metabolically less efficient reactions.
         These reactions are found when running an FBA and setting the  
@@ -118,44 +118,33 @@ class PreProcess:
             
         tol = 1e-6
 
-        self.model.objective = self.objective
-        fba_solution = self.model.optimize()
+        self._model.objective = self._objective
+        fba_solution = self._model.optimize()
 
-        wt_lower_bound = self.model.reactions.get_by_id(self.objective).lower_bound
-        self.model.reactions.get_by_id(self.objective).lower_bound = fba_solution.objective_value
+        wt_lower_bound = self._model.reactions.get_by_id(self._objective).lower_bound
+        self._model.reactions.get_by_id(self._objective).lower_bound = fba_solution.objective_value
 
-        fva = cobra.flux_analysis.flux_variability_analysis(self.model, fraction_of_optimum=0.95)
+        fva = cobra.flux_analysis.flux_variability_analysis(self._model, fraction_of_optimum=0.95)
         mle = fva.loc[ (abs(fva['minimum']) < tol ) & (abs(fva['maximum']) < tol)]
         mle = mle.index.tolist()
         
-        self.model.reactions.get_by_id(self.objective).lower_bound = wt_lower_bound
+        self._model.reactions.get_by_id(self._objective).lower_bound = wt_lower_bound
         
-        self.mle_reactions = mle
-        return self.mle_reactions
+        self._mle_reactions = mle
+        return self._mle_reactions
     
     
-    def __remove_model_reactions(self):
+    def _remove_model_reactions(self):
         """
         A function used to set the lower and upper bounds of certain reactions to 0
         (it turns off reactions)
         """
                                 
-        for reaction in self.removed_reactions:
-            self.model.reactions.get_by_id(reaction).lower_bound = 0
-            self.model.reactions.get_by_id(reaction).upper_bound = 0
+        for reaction in self._removed_reactions:
+            self._model.reactions.get_by_id(reaction).lower_bound = 0
+            self._model.reactions.get_by_id(reaction).upper_bound = 0
             
-        return self.model
-    
-    
-    def __cobra_dingo_tuple(self):
-        """
-        A function used to convert the reduced cobra model to a dingo-type tuple
-        """
-        self.dingo_tuple = parse_cobra_model(self.model)
-        new_lb = self.dingo_tuple[0]
-        new_ub = self.dingo_tuple[1]
-        
-        return new_lb, new_ub
+        return self._model
    
             
     def reduce(self, extend):
@@ -180,20 +169,19 @@ class PreProcess:
         
         The outputs are
         (a) A list of the removed reactions ids
-        (b) The updated reactions lower bounds
-        (c) The updated reactions upper bounds
+        (b) A reduced dingo model
         """        
         
         # create a list from the combined blocked, zero-flux, mle reactions
-        blocked_mle_zero = self.blocked_reactions + self.mle_reactions + self.zero_flux_reactions
+        blocked_mle_zero = self._blocked_reactions + self._mle_reactions + self._zero_flux_reactions
         list_removed_reactions = list(set(blocked_mle_zero))        
-        self.removed_reactions = list_removed_reactions
+        self._removed_reactions = list_removed_reactions
    
         # remove these reactions from the model
-        self.__remove_model_reactions()
+        self._remove_model_reactions()
                      
-        remained_reactions = list((Counter(self.initial_reactions)-Counter(self.removed_reactions)).elements())
-        remained_reactions = list((Counter(remained_reactions)-Counter(self.essential_reactions)).elements())
+        remained_reactions = list((Counter(self._initial_reactions)-Counter(self._removed_reactions)).elements())
+        remained_reactions = list((Counter(remained_reactions)-Counter(self._essential_reactions)).elements())
         
         tol = 1e-6
         
@@ -204,54 +192,54 @@ class PreProcess:
         additional_removed_reactions_count = 0       
         for reaction in remained_reactions:
             
-            fba_solution_before = self.model.optimize().objective_value
+            fba_solution_before = self._model.optimize().objective_value
                         
-            initial_lower = self.model.reactions.get_by_id(reaction).lower_bound
-            initial_upper = self.model.reactions.get_by_id(reaction).upper_bound
+            initial_lower = self._model.reactions.get_by_id(reaction).lower_bound
+            initial_upper = self._model.reactions.get_by_id(reaction).upper_bound
             
             # perform a knock-out and check the output
-            self.model.reactions.get_by_id(reaction).lower_bound = 0
-            self.model.reactions.get_by_id(reaction).upper_bound = 0
+            self._model.reactions.get_by_id(reaction).lower_bound = 0
+            self._model.reactions.get_by_id(reaction).upper_bound = 0
     
-            fba_solution_after = self.model.optimize().objective_value
+            fba_solution_after = self._model.optimize().objective_value
             
             if fba_solution_after != None and (extend == 1):
                 if (abs(fba_solution_after - fba_solution_before) < tol):
-                    self.removed_reactions.append(reaction)
+                    self._removed_reactions.append(reaction)
                     additional_removed_reactions_count += 1
               
-            self.model.reactions.get_by_id(reaction).upper_bound = initial_upper
-            self.model.reactions.get_by_id(reaction).lower_bound = initial_lower
+            self._model.reactions.get_by_id(reaction).upper_bound = initial_upper
+            self._model.reactions.get_by_id(reaction).lower_bound = initial_lower
             
             
         # compare FBA solution before and after the removal of additional reactions
-        fba_solution_initial = self.model.optimize().objective_value
-        self.__remove_model_reactions()        
-        fba_solution_final = self.model.optimize().objective_value
+        fba_solution_initial = self._model.optimize().objective_value
+        self._remove_model_reactions()        
+        fba_solution_final = self._model.optimize().objective_value
 
         
         # get a list of the additional reactions to be removed
-        additional_removed_reactions_list = (self.removed_reactions[len(self.removed_reactions)-additional_removed_reactions_count:])
+        additional_removed_reactions_list = (self._removed_reactions[len(self._removed_reactions)-additional_removed_reactions_count:])
         
         # if FBA solution after removal is infesible or altered
         # restore the initial reactions bounds
         if (fba_solution_final == None):
             for reaction in additional_removed_reactions_list:
-                self.model.reactions.get_by_id(reaction).bounds = self.reaction_bounds_dict[reaction]
-                self.removed_reactions.remove(reaction)
-            print(len(self.removed_reactions), "of the", len(self.initial_reactions), "reactions were removed from the model with extend set to", extend)
+                self._model.reactions.get_by_id(reaction).bounds = self._reaction_bounds_dict[reaction]
+                self._removed_reactions.remove(reaction)
+            print(len(self._removed_reactions), "of the", len(self._initial_reactions), "reactions were removed from the model with extend set to", extend)
 
         elif(abs(fba_solution_final - fba_solution_initial) > tol):
             for reaction in additional_removed_reactions_list:
-                self.model.reactions.get_by_id(reaction).bounds = self.reaction_bounds_dict[reaction]
+                self._model.reactions.get_by_id(reaction).bounds = self._reaction_bounds_dict[reaction]
                 self.removed_reactions.remove(reaction)
-            print(len(self.removed_reactions), "of the", len(self.initial_reactions), "reactions were removed from the model with extend set to", extend) 
+            print(len(self._removed_reactions), "of the", len(self._initial_reactions), "reactions were removed from the model with extend set to", extend) 
 
         else:
-            print(len(self.removed_reactions), "of the", len(self.initial_reactions), "reactions were removed from the model with extend set to", extend)
+            print(len(self._removed_reactions), "of the", len(self._initial_reactions), "reactions were removed from the model with extend set to", extend)
 
     
-        # call this functon to get updated bounds
-        new_lower_bounds, new_upper_bounds = self.__cobra_dingo_tuple()
+        # call this functon to convert cobra to dingo model
+        self._dingo_model = MetabolicNetwork.from_cobra_model(self._model)
 
-        return self.removed_reactions, new_lower_bounds, new_upper_bounds
+        return self._removed_reactions, self._dingo_model 

--- a/dingo/preprocess.py
+++ b/dingo/preprocess.py
@@ -16,6 +16,7 @@ class PreProcess:
         self.zero_flux_reactions = self.zero_flux()
         self.blocked_reactions = self.blocked()
         self.mle_reactions = self.metabolically_less_efficient()
+        self.dingo_model = self.cobra_dingo_conversion()
         self.removed_reactions = []
 
         
@@ -145,9 +146,17 @@ class PreProcess:
             self.model.reactions.get_by_id(reaction).upper_bound = 0
             
         return self.model
-        
+    
+    
+    def cobra_dingo_conversion(self):
+        """
+        A function used to convert the reduced cobra model to a dingo model
+        """
+        self.dingo_model = parse_cobra_model(self.model)
+        return self.dingo_model
+   
             
-    def removed(self, extend):
+    def reduce(self, extend):
         """
         A function that calls "remove_model_reactions" function
         and removes blocked, zero-flux and metabolically less efficient reactions.
@@ -159,6 +168,13 @@ class PreProcess:
         do not affect the value of the objective function. These reactions 
         are removed simultaneously. If the simultaneous removal produces an infesible
         solution (or 0) to the objective function, they are restored with their initial bounds.
+        
+        The dingo model is then created from the cobra model 
+        using the "cobra_dingo_conversion" function.
+        
+        The outputs are
+        (a) A list of the removed reactions ids
+        (b) The reduced dingo model
         """        
         
         blocked_mle_zero = self.blocked_reactions + self.mle_reactions + self.zero_flux_reactions
@@ -217,15 +233,7 @@ class PreProcess:
             print(len(self.removed_reactions), "of the", len(self.initial_reactions), "reactions were removed from the model with extend set to", extend) 
 
         else:
-            print(len(self.removed_reactions), "of the", len(self.initial_reactions), "reactions were removed from the model with extend set to", extend)      
+            print(len(self.removed_reactions), "of the", len(self.initial_reactions), "reactions were removed from the model with extend set to", extend)
+            
         
-        return self.removed_reactions
-    
-    
-    def dingo_model_conversion(self):
-        """
-        A function used to convert the reduced cobra model to a dingo model
-        """
-        dingo_model = parse_cobra_model(self.model)
-        return dingo_model
-
+        return self.removed_reactions, self.cobra_dingo_conversion() 

--- a/tests/preprocess.py
+++ b/tests/preprocess.py
@@ -5,15 +5,13 @@ from dingo.preprocess import PreProcess
 
 class TestFba(unittest.TestCase):
 
-    def test_fba_json(self):
+    def test_preprocess(self):
 
-        #input_file_json = os.getcwd() + "/ext_data/e_coli_core.json"
+        input_file_json = os.getcwd() + "/ext_data/e_coli_core.json"
         PreProcess.blocked(input_file_json)
         #model = MetabolicNetwork.from_json(input_file_json)
-        #model.set_slow_mode()
-        #res = model.fba()
 
-        #self.assertTrue(abs(res[1] - 0.8739215067486387) < 1e-03)
+        #self.assertTrue()
         
         
 

--- a/tests/preprocess.py
+++ b/tests/preprocess.py
@@ -3,7 +3,7 @@ from cobra.io import load_json_model
 from dingo.preprocess import PreProcess
 import unittest
 import numpy as np
-
+import cobra
 
 class TestPreprocess(unittest.TestCase):
 
@@ -20,16 +20,16 @@ class TestPreprocess(unittest.TestCase):
 
 
         # call the reduce function from the PreProcess class 
-        # with extend=0 to remove reactions from the model        
-        obj = PreProcess(cobra_model)  
-        removed_reactions, dingo_model = obj.reduce(extend=0)      
+        # with extend=False to remove reactions from the model        
+        obj = PreProcess(cobra_model, open_exchanges=False)  
+        removed_reactions, dingo_model = obj.reduce(extend=False)      
         
-        # calculate the count of removed reactions with extend set to 0        
+        # calculate the count of removed reactions with extend set to False        
         removed_reactions_count = len(removed_reactions)
         self.assertTrue( 46 - removed_reactions_count == 0 )
 
         # calculate the count of reactions with bounds equal to 0 
-        # with extend set to 0 from the dingo model
+        # with extend set to False from the dingo model
         dingo_removed_reactions = np.sum((dingo_model.lb == 0) & (dingo_model.ub == 0))
         self.assertTrue( 46 - dingo_removed_reactions == 0 )
         
@@ -43,22 +43,22 @@ class TestPreprocess(unittest.TestCase):
         cobra_model = load_json_model("ext_data/e_coli_core.json")        
 
         # call the reduce function from the PreProcess class 
-        # with extend=1 to remove additional reactions from the model        
-        obj = PreProcess(cobra_model)        
-        removed_reactions, dingo_model = obj.reduce(extend=1)        
+        # with extend=True to remove additional reactions from the model        
+        obj = PreProcess(cobra_model, open_exchanges=False)        
+        removed_reactions, dingo_model = obj.reduce(extend=True)        
     
-        # calculate the count of removed reactions with extend set to 1        
+        # calculate the count of removed reactions with extend set to True        
         removed_reactions_count = len(removed_reactions)
         self.assertTrue( 47 - removed_reactions_count == 0 )
 
         # calculate the count of reactions with bounds equal to 0 
-        # with extend set to 1 from the dingo model
+        # with extend set to True from the dingo model
         dingo_removed_reactions = np.sum((dingo_model.lb == 0) & (dingo_model.ub == 0))
         self.assertTrue( 47 - dingo_removed_reactions == 0 )
         
         # perform an FBA to check the result after reactions removal
         res = dingo_model.fba()
-        self.assertTrue(abs(res[1] - 0.8739215067486387) < 1e-03)       
+        self.assertTrue(abs(res[1] - 0.8739215067486387) < 1e-03)   
 
 
 if __name__ == "__main__":

--- a/tests/preprocess.py
+++ b/tests/preprocess.py
@@ -2,7 +2,7 @@
 from cobra.io import load_json_model
 from dingo.preprocess import PreProcess
 import unittest
-import os
+import numpy as np
 
 
 class TestPreprocess(unittest.TestCase):
@@ -21,8 +21,13 @@ class TestPreprocess(unittest.TestCase):
 
 
         # calculate the count of removed reactions with extend set to 0
-        removed_reactions_count = len(obj.removed(extend=0)) 
-        self.assertTrue( 46 - removed_reactions_count == 0 )
+        removed_reactions, dingo_model = obj.reduce(extend=0)
+        removed_reactions_count = len(removed_reactions)
+        self.assertTrue( 46 - removed_reactions_count == 0 )        
+
+        # calculate the count of removed reactions with extend set to 0 from the dingo model       
+        dingo_removed_reactions = np.sum((dingo_model[0] == 0) & (dingo_model[1] == 0))
+        self.assertTrue( 46 - dingo_removed_reactions == 0 )
         
         # calculate the count of reactions with bounds equal to 0 with extend set to 0
         zero_flux_count = 0
@@ -32,13 +37,23 @@ class TestPreprocess(unittest.TestCase):
                 zero_flux_count += 1
             
         self.assertTrue( 46 - zero_flux_count == 0 )
+        
+        fba_solution = model.optimize()   
+        self.assertTrue(abs(fba_solution.objective_value - 0.8739215067486387) < 1e-03)
+
 
 
         # calculate the count of removed reactions with extend set to 1
-        removed_reactions_count = len(obj.removed(extend=1)) 
+        removed_reactions, dingo_model = obj.reduce(extend=1)
+        removed_reactions_count = len(removed_reactions)
         self.assertTrue( 47 - removed_reactions_count == 0 )
+        
+        # calculate the count of removed reactions with extend set to 1 from the dingo model       
+        dingo_removed_reactions = np.sum((dingo_model[0] == 0) & (dingo_model[1] == 0))
+        self.assertTrue( 47 - dingo_removed_reactions == 0 )
+
                    
-        # calculate the count of reactions with bounds equal to 0 with extend set to 0        
+        # calculate the count of reactions with bounds equal to 0 with extend set to 1        
         zero_flux_count = 0
         for reaction_id in initial_reactions_ids:
             bounds = model.reactions.get_by_id(reaction_id).bounds
@@ -46,8 +61,7 @@ class TestPreprocess(unittest.TestCase):
                 zero_flux_count += 1
             
         self.assertTrue( 47 - zero_flux_count == 0 )
-
-              
+      
         fba_solution = model.optimize()   
         self.assertTrue(abs(fba_solution.objective_value - 0.8739215067486387) < 1e-03)
         

--- a/tests/preprocess.py
+++ b/tests/preprocess.py
@@ -11,11 +11,10 @@ class TestPreprocess(unittest.TestCase):
 
         model = load_json_model("ext_data/e_coli_core.json")
         obj = PreProcess(model)
-        
-        essentials = len(obj.essential_reactions)
 
-        self.assertTrue( 27-essentials < 0.01)
+        removed_reactions_count = len(obj.removed_reactions_ids())
         
+        self.assertTrue( 55 - removed_reactions_count == 0 )
         
 
 if __name__ == "__main__":

--- a/tests/preprocess.py
+++ b/tests/preprocess.py
@@ -3,7 +3,7 @@ import unittest
 import os
 from dingo.preprocess import PreProcess
 
-class TestFba(unittest.TestCase):
+class TestPreprocess(unittest.TestCase):
 
     def test_preprocess(self):
 

--- a/tests/preprocess.py
+++ b/tests/preprocess.py
@@ -1,17 +1,20 @@
 
+from cobra.io import load_json_model
+from dingo.preprocess import PreProcess
 import unittest
 import os
-from dingo.preprocess import PreProcess
+
 
 class TestPreprocess(unittest.TestCase):
 
     def test_preprocess(self):
 
-        input_file_json = os.getcwd() + "/ext_data/e_coli_core.json"
-        PreProcess.blocked(input_file_json)
-        #model = MetabolicNetwork.from_json(input_file_json)
+        model = load_json_model("ext_data/e_coli_core.json")
+        obj = PreProcess(model)
+        
+        essentials = len(obj.essential_reactions)
 
-        #self.assertTrue()
+        self.assertTrue( 27-essentials < 0.01)
         
         
 

--- a/tests/preprocess.py
+++ b/tests/preprocess.py
@@ -11,10 +11,45 @@ class TestPreprocess(unittest.TestCase):
 
         model = load_json_model("ext_data/e_coli_core.json")
         obj = PreProcess(model)
-
-        removed_reactions_count = len(obj.removed_reactions_ids())
         
-        self.assertTrue( 55 - removed_reactions_count == 0 )
+        
+        # find reaction ids from the loaded model
+        initial_reactions_ids = []    
+        for reaction in model.reactions:
+            reaction_id = reaction.id
+            initial_reactions_ids.append(reaction_id)        
+
+
+        # calculate the count of removed reactions with extend set to 0
+        removed_reactions_count = len(obj.removed(extend=0)) 
+        self.assertTrue( 46 - removed_reactions_count == 0 )
+        
+        # calculate the count of reactions with bounds equal to 0 with extend set to 0
+        zero_flux_count = 0
+        for reaction_id in initial_reactions_ids:
+            bounds = model.reactions.get_by_id(reaction_id).bounds
+            if ((bounds[0] == 0) and (bounds[1] == 0)):
+                zero_flux_count += 1
+            
+        self.assertTrue( 46 - zero_flux_count == 0 )
+
+
+        # calculate the count of removed reactions with extend set to 1
+        removed_reactions_count = len(obj.removed(extend=1)) 
+        self.assertTrue( 47 - removed_reactions_count == 0 )
+                   
+        # calculate the count of reactions with bounds equal to 0 with extend set to 0        
+        zero_flux_count = 0
+        for reaction_id in initial_reactions_ids:
+            bounds = model.reactions.get_by_id(reaction_id).bounds
+            if ((bounds[0] == 0) and (bounds[1] == 0)):
+                zero_flux_count += 1
+            
+        self.assertTrue( 47 - zero_flux_count == 0 )
+
+              
+        fba_solution = model.optimize()   
+        self.assertTrue(abs(fba_solution.objective_value - 0.8739215067486387) < 1e-03)
         
 
 if __name__ == "__main__":

--- a/tests/preprocess.py
+++ b/tests/preprocess.py
@@ -3,68 +3,71 @@ from cobra.io import load_json_model
 from dingo.preprocess import PreProcess
 import unittest
 import numpy as np
+from dingo import MetabolicNetwork
 
 
 class TestPreprocess(unittest.TestCase):
 
     def test_preprocess(self):
 
-        model = load_json_model("ext_data/e_coli_core.json")
-        obj = PreProcess(model)
-        
-        
+        # load models in cobra and dingo format
+        cobra_model = load_json_model("ext_data/e_coli_core.json")        
+        dingo_model = MetabolicNetwork.from_json('ext_data/e_coli_core.json')
+
         # find reaction ids from the loaded model
         initial_reactions_ids = []    
-        for reaction in model.reactions:
+        for reaction in cobra_model.reactions:
             reaction_id = reaction.id
-            initial_reactions_ids.append(reaction_id)        
+            initial_reactions_ids.append(reaction_id)
 
+      
 
-        # calculate the count of removed reactions with extend set to 0
-        removed_reactions, dingo_model = obj.reduce(extend=0)
+        # call the reduce function from the PreProcess class 
+        # with extend=0 to remove reactions from the model        
+        obj = PreProcess(cobra_model)        
+        removed_reactions, new_lower_bounds, new_upper_bounds = obj.reduce(extend=0)
+        
+        # calculate the count of removed reactions with extend set to 0        
         removed_reactions_count = len(removed_reactions)
-        self.assertTrue( 46 - removed_reactions_count == 0 )        
+        self.assertTrue( 46 - removed_reactions_count == 0 )
 
-        # calculate the count of removed reactions with extend set to 0 from the dingo model       
-        dingo_removed_reactions = np.sum((dingo_model[0] == 0) & (dingo_model[1] == 0))
+        # calculate the count of reactions with bounds equal to 0 
+        # with extend set to 0 from the dingo model
+        dingo_model.lb = new_lower_bounds
+        dingo_model.ub = new_upper_bounds        
+        dingo_removed_reactions = np.sum((dingo_model.lb == 0) & (dingo_model.ub == 0))
         self.assertTrue( 46 - dingo_removed_reactions == 0 )
         
-        # calculate the count of reactions with bounds equal to 0 with extend set to 0
-        zero_flux_count = 0
-        for reaction_id in initial_reactions_ids:
-            bounds = model.reactions.get_by_id(reaction_id).bounds
-            if ((bounds[0] == 0) and (bounds[1] == 0)):
-                zero_flux_count += 1
-            
-        self.assertTrue( 46 - zero_flux_count == 0 )
+        # perform an FBA to check the result after reactions removal
+        res = dingo_model.fba()
+        self.assertTrue(abs(res[1] - 0.8739215067486387) < 1e-03)       
+
+
+
+        # load models in cobra and dingo format again to restore bounds
+        cobra_model = load_json_model("ext_data/e_coli_core.json")        
+        dingo_model = MetabolicNetwork.from_json('ext_data/e_coli_core.json')
+
+        # call the reduce function from the PreProcess class 
+        # with extend=1 to remove additional reactions from the model        
+        obj = PreProcess(cobra_model)        
+        removed_reactions, new_lower_bounds, new_upper_bounds = obj.reduce(extend=1)
         
-        fba_solution = model.optimize()   
-        self.assertTrue(abs(fba_solution.objective_value - 0.8739215067486387) < 1e-03)
-
-
-
-        # calculate the count of removed reactions with extend set to 1
-        removed_reactions, dingo_model = obj.reduce(extend=1)
+        # calculate the count of removed reactions with extend set to 1        
         removed_reactions_count = len(removed_reactions)
         self.assertTrue( 47 - removed_reactions_count == 0 )
-        
-        # calculate the count of removed reactions with extend set to 1 from the dingo model       
-        dingo_removed_reactions = np.sum((dingo_model[0] == 0) & (dingo_model[1] == 0))
-        self.assertTrue( 47 - dingo_removed_reactions == 0 )
 
-                   
-        # calculate the count of reactions with bounds equal to 0 with extend set to 1        
-        zero_flux_count = 0
-        for reaction_id in initial_reactions_ids:
-            bounds = model.reactions.get_by_id(reaction_id).bounds
-            if ((bounds[0] == 0) and (bounds[1] == 0)):
-                zero_flux_count += 1
-            
-        self.assertTrue( 47 - zero_flux_count == 0 )
-      
-        fba_solution = model.optimize()   
-        self.assertTrue(abs(fba_solution.objective_value - 0.8739215067486387) < 1e-03)
+        # calculate the count of reactions with bounds equal to 0 
+        # with extend set to 1 from the dingo model
+        dingo_model.lb = new_lower_bounds
+        dingo_model.ub = new_upper_bounds        
+        dingo_removed_reactions = np.sum((dingo_model.lb == 0) & (dingo_model.ub == 0))
+        self.assertTrue( 47 - dingo_removed_reactions == 0 )
         
+        # perform an FBA to check the result after reactions removal
+        res = dingo_model.fba()
+        self.assertTrue(abs(res[1] - 0.8739215067486387) < 1e-03)       
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/preprocess.py
+++ b/tests/preprocess.py
@@ -1,9 +1,9 @@
 
 from cobra.io import load_json_model
+from dingo import MetabolicNetwork
 from dingo.preprocess import PreProcess
 import unittest
 import numpy as np
-import cobra
 
 class TestPreprocess(unittest.TestCase):
 
@@ -11,18 +11,18 @@ class TestPreprocess(unittest.TestCase):
 
         # load cobra model
         cobra_model = load_json_model("ext_data/e_coli_core.json")
-
-        # find reaction ids from the loaded model
-        initial_reactions_ids = []    
-        for reaction in cobra_model.reactions:
-            reaction_id = reaction.id
-            initial_reactions_ids.append(reaction_id)
+        
+        # convert cobra to dingo model
+        initial_dingo_model = MetabolicNetwork.from_cobra_model(cobra_model)
+        
+        # perform an FBA to find the initial FBA solution
+        initial_fba_solution = initial_dingo_model.fba()[1]
 
 
         # call the reduce function from the PreProcess class 
         # with extend=False to remove reactions from the model        
-        obj = PreProcess(cobra_model, open_exchanges=False)  
-        removed_reactions, dingo_model = obj.reduce(extend=False)      
+        obj = PreProcess(cobra_model, tol=1e-5, open_exchanges=False)  
+        removed_reactions, final_dingo_model = obj.reduce(extend=False)      
         
         # calculate the count of removed reactions with extend set to False        
         removed_reactions_count = len(removed_reactions)
@@ -30,22 +30,24 @@ class TestPreprocess(unittest.TestCase):
 
         # calculate the count of reactions with bounds equal to 0 
         # with extend set to False from the dingo model
-        dingo_removed_reactions = np.sum((dingo_model.lb == 0) & (dingo_model.ub == 0))
+        dingo_removed_reactions = np.sum((final_dingo_model.lb == 0) & (final_dingo_model.ub == 0))
         self.assertTrue( 46 - dingo_removed_reactions == 0 )
         
-        # perform an FBA to check the result after reactions removal
-        res = dingo_model.fba()
-        self.assertTrue(abs(res[1] - 0.8739215067486387) < 1e-03)       
-
+        # perform an FBA to check the solution after reactions removal
+        final_fba_solution = final_dingo_model.fba()[1]
+        self.assertTrue(abs(final_fba_solution - initial_fba_solution) < 1e-03)       
 
 
         # load models in cobra and dingo format again to restore bounds
-        cobra_model = load_json_model("ext_data/e_coli_core.json")        
-
+        cobra_model = load_json_model("ext_data/e_coli_core.json")
+        
+        # convert cobra to dingo model
+        initial_dingo_model = MetabolicNetwork.from_cobra_model(cobra_model)
+     
         # call the reduce function from the PreProcess class 
         # with extend=True to remove additional reactions from the model        
-        obj = PreProcess(cobra_model, open_exchanges=False)        
-        removed_reactions, dingo_model = obj.reduce(extend=True)        
+        obj = PreProcess(cobra_model, tol=1e-6, open_exchanges=False)        
+        removed_reactions, final_dingo_model = obj.reduce(extend=True)        
     
         # calculate the count of removed reactions with extend set to True        
         removed_reactions_count = len(removed_reactions)
@@ -53,12 +55,12 @@ class TestPreprocess(unittest.TestCase):
 
         # calculate the count of reactions with bounds equal to 0 
         # with extend set to True from the dingo model
-        dingo_removed_reactions = np.sum((dingo_model.lb == 0) & (dingo_model.ub == 0))
+        dingo_removed_reactions = np.sum((final_dingo_model.lb == 0) & (final_dingo_model.ub == 0))
         self.assertTrue( 47 - dingo_removed_reactions == 0 )
         
         # perform an FBA to check the result after reactions removal
-        res = dingo_model.fba()
-        self.assertTrue(abs(res[1] - 0.8739215067486387) < 1e-03)   
+        final_fba_solution = final_dingo_model.fba()[1]
+        self.assertTrue(abs(final_fba_solution - initial_fba_solution) < 1e-03)   
 
 
 if __name__ == "__main__":

--- a/tests/preprocess.py
+++ b/tests/preprocess.py
@@ -1,0 +1,23 @@
+
+import unittest
+import os
+from dingo.preprocess import PreProcess
+
+class TestFba(unittest.TestCase):
+
+    def test_fba_json(self):
+
+        #input_file_json = os.getcwd() + "/ext_data/e_coli_core.json"
+        PreProcess.blocked(input_file_json)
+        #model = MetabolicNetwork.from_json(input_file_json)
+        #model.set_slow_mode()
+        #res = model.fba()
+
+        #self.assertTrue(abs(res[1] - 0.8739215067486387) < 1e-03)
+        
+        
+
+if __name__ == "__main__":
+    unittest.main()
+
+ 

--- a/tests/preprocess.py
+++ b/tests/preprocess.py
@@ -3,16 +3,14 @@ from cobra.io import load_json_model
 from dingo.preprocess import PreProcess
 import unittest
 import numpy as np
-from dingo import MetabolicNetwork
 
 
 class TestPreprocess(unittest.TestCase):
 
     def test_preprocess(self):
 
-        # load models in cobra and dingo format
-        cobra_model = load_json_model("ext_data/e_coli_core.json")        
-        dingo_model = MetabolicNetwork.from_json('ext_data/e_coli_core.json')
+        # load cobra model
+        cobra_model = load_json_model("ext_data/e_coli_core.json")
 
         # find reaction ids from the loaded model
         initial_reactions_ids = []    
@@ -20,12 +18,11 @@ class TestPreprocess(unittest.TestCase):
             reaction_id = reaction.id
             initial_reactions_ids.append(reaction_id)
 
-      
 
         # call the reduce function from the PreProcess class 
         # with extend=0 to remove reactions from the model        
-        obj = PreProcess(cobra_model)        
-        removed_reactions, new_lower_bounds, new_upper_bounds = obj.reduce(extend=0)
+        obj = PreProcess(cobra_model)  
+        removed_reactions, dingo_model = obj.reduce(extend=0)      
         
         # calculate the count of removed reactions with extend set to 0        
         removed_reactions_count = len(removed_reactions)
@@ -33,8 +30,6 @@ class TestPreprocess(unittest.TestCase):
 
         # calculate the count of reactions with bounds equal to 0 
         # with extend set to 0 from the dingo model
-        dingo_model.lb = new_lower_bounds
-        dingo_model.ub = new_upper_bounds        
         dingo_removed_reactions = np.sum((dingo_model.lb == 0) & (dingo_model.ub == 0))
         self.assertTrue( 46 - dingo_removed_reactions == 0 )
         
@@ -46,21 +41,18 @@ class TestPreprocess(unittest.TestCase):
 
         # load models in cobra and dingo format again to restore bounds
         cobra_model = load_json_model("ext_data/e_coli_core.json")        
-        dingo_model = MetabolicNetwork.from_json('ext_data/e_coli_core.json')
 
         # call the reduce function from the PreProcess class 
         # with extend=1 to remove additional reactions from the model        
         obj = PreProcess(cobra_model)        
-        removed_reactions, new_lower_bounds, new_upper_bounds = obj.reduce(extend=1)
-        
+        removed_reactions, dingo_model = obj.reduce(extend=1)        
+    
         # calculate the count of removed reactions with extend set to 1        
         removed_reactions_count = len(removed_reactions)
         self.assertTrue( 47 - removed_reactions_count == 0 )
 
         # calculate the count of reactions with bounds equal to 0 
         # with extend set to 1 from the dingo model
-        dingo_model.lb = new_lower_bounds
-        dingo_model.ub = new_upper_bounds        
         dingo_removed_reactions = np.sum((dingo_model.lb == 0) & (dingo_model.ub == 0))
         self.assertTrue( 47 - dingo_removed_reactions == 0 )
         


### PR DESCRIPTION
Aim of this PR is to provide a "PreProcess" class to dingo that identifies and removes certain reactions.

This removal is achieved by setting the lower and upper bounds of reactions to 0.

3 types of reactions are identified and removed from the metabolic models:

1. Blocked
2. Zero-flux
3. Metabolically less efficient

The metabolic model given as an input to the "PreProcess" class must be in a cobra format. A list with the removed reactions ids and a reduced dingo model are returned from the "reduce" function of this class.

`from cobra.io import load_json_model`

`cobra_model = load_json_model("ext_data/e_coli_core.json")`

`obj = PreProcess(cobra_model)`

`removed_reactions, dingo_model = obj.reduce(extend=0)`

In addition, reactions that do not affect the objective function when sequentially knocked-down can be removed from the model.
To perform this additional removal of reactions, the "extend" parameter from the "reduce" function is set to 1.

`removed_reactions, dingo_model = obj.reduce(extend=1)`

However, this may lead to infesible solutions in large models. When this happens, these reactions are restored to their initial bounds.

This [unittest](https://github.com/SotirisTouliopoulos/dingo/blob/preprocess/tests/preprocess.py) shows how the PreProcess  class works with the E.coli core model. It removes 46 reactions with "extend" set to 0 and 47 reactions with "extend" set to 1. An FBA is also called after reactions removal and the value of the objective function is the same, as the initial one.

This new [script](https://github.com/SotirisTouliopoulos/dingo/blob/preprocess/dingo/preprocess.py) in the dingo/ directory contains the code for the PreProcess class.
