### PR TITLE
Clarify local installation steps in tutorial notebookClarify installation steps in tutorial notebook

### DIFF
--- a/tutorials/dingo_tutorial.ipynb
+++ b/tutorials/dingo_tutorial.ipynb
@@ -11,6 +11,24 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "⚠️ **Note (Updated)**\n",
+        "\n",
+        "This installation section was originally written for Google Colab.\n",
+        "For local development and current setups, please refer to the main\n",
+        "`README.md` and use the recommended installation method.\n",
+        "\n",
+        "### Recommended (Local Installation)\n",
+        "\n",
+        "```bash\n",
+        "git clone https://github.com/GeomScale/dingo.git\n",
+        "cd dingo\n",
+        "poetry install\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
       "metadata": {
         "id": "04-ezSozK3QT"
       },


### PR DESCRIPTION
This PR clarifies that the installation section in the tutorial notebook
was originally written for Google Colab and adds a recommended local
installation method using poetry consistent with the main README.

This improves onboarding for new contributors.
